### PR TITLE
Support flat storage for single-state machines

### DIFF
--- a/source/rafcon/core/state_machine.py
+++ b/source/rafcon/core/state_machine.py
@@ -125,14 +125,17 @@ class StateMachine(Observable, JSONObject, Hashable):
 
     @staticmethod
     def state_machine_to_dict(state_machine):
+        from rafcon.core.states.execution_state import ExecutionState
         from rafcon.core.storage.storage import get_storage_id_for_state
         dict_representation = {
-            'root_state_storage_id': get_storage_id_for_state(state_machine.root_state),
             'state_machine_version': state_machine.version,
             'used_rafcon_version': rafcon.__version__,
             'creation_time': state_machine.creation_time,
             'last_update': state_machine.last_update,
         }
+        if not isinstance(state_machine.root_state, ExecutionState):
+            dict_representation['root_state_storage_id'] = get_storage_id_for_state(state_machine.root_state)
+
         return dict_representation
 
     def start(self):

--- a/source/rafcon/gui/helpers/state_machine.py
+++ b/source/rafcon/gui/helpers/state_machine.py
@@ -1043,9 +1043,11 @@ def get_root_state_file_path(sm_file_system_path):
         except ValueError:
             return
         if 'root_state_id' not in sm_dict and 'root_state_storage_id' not in sm_dict:
-            return
-        root_state_folder = sm_dict['root_state_id'] if 'root_state_id' in sm_dict else sm_dict['root_state_storage_id']
-        return os.path.join(sm_file_system_path, root_state_folder, storage.FILE_NAME_CORE_DATA)
+            # This is a single-state state machine, so its data is stored in the same directory
+            return os.path.join(sm_file_system_path, storage.FILE_NAME_CORE_DATA)
+        else:
+            root_state_folder = sm_dict['root_state_id'] if 'root_state_id' in sm_dict else sm_dict['root_state_storage_id']
+            return os.path.join(sm_file_system_path, root_state_folder, storage.FILE_NAME_CORE_DATA)
 
 
 def get_root_state_name_of_sm_file_system_path(file_system_path):

--- a/source/rafcon/gui/models/abstract_state.py
+++ b/source/rafcon/gui/models/abstract_state.py
@@ -528,7 +528,11 @@ class AbstractStateModel(MetaModel, Hashable):
         :param str copy_path: Optional copy path if meta data is not stored to the file system path of state machine
         """
         if copy_path:
-            meta_file_path_json = os.path.join(copy_path, self.state.get_storage_path(), storage.FILE_NAME_META_DATA)
+            from rafcon.core.states.execution_state import ExecutionState
+            if self.state.is_root_state and isinstance(self.state, ExecutionState):
+                meta_file_path_json = os.path.join(copy_path, storage.FILE_NAME_META_DATA)
+            else:
+                meta_file_path_json = os.path.join(copy_path, self.state.get_storage_path(), storage.FILE_NAME_META_DATA)
         else:
             if self.state.file_system_path is None:
                 logger.error("Meta data of {0} can be stored temporary arbitrary but by default first after the "


### PR DESCRIPTION
In our use case, we'll create a lot of library states which are stand alone `ExecutionState`s tied to our robot's capabilities. As it stands, we'd have a folder structure like this:

```
common_states/
    move_to_named_poi/
        state_machine.json
        meta_data.json
        move_to_named_poi_MOVE_TO_NAMED_POI/
            script.py
            code_data.json
            meta_data.json
```

This is pretty heavy wrapping for a single script file, so we'd greatly prefer a structure like this:

```
common_states/
    move_to_named_poi/
        state_machine.json
        meta_data.json
        script.py
        code_data.json
```

This PR has changes to support this layout. The loading code evaluates whether a state machine is of this type by looking for a state in the current folder whenever "root_state_storage_id" is absent. Saving will adopt this format if the state machine contains exactly one state and the state is an `ExecutionState`.

Please do feel free to recommend alternative implementations. Just wanted to start a discussion about this as a possible convenience.

---
Please make sure that you can tick the following items at latest before
merging the pull request:

- [ ] added description what has been changed and why
- [ ] if appropriate, include changes into the changelog
- [ ] if appropriate, adapt/extend the documentation
- [x] as external contributor, you need to sign the Contributor License Agreement (CLA), which can be found in the root directory of the repository

For reviewers:
- [ ] after merging the pull request, check if everything looks like expected (especially the changelog)
