### PR TITLE
feat(start_from_here): add execution history replay functionality

### DIFF
--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -305,14 +305,14 @@ class ExecutionEngine(Observable):
         :param history_item: The execution history item to replay from (must be a CallItem)
         :param state_machine: The state machine to execute
         """
-        # Build runtime_map: separate scoped_data for each ancestor path
+        # Build runtime_map: skip root, include target and ancestors
         path_parts = history_item.path.split('/')
-        ancestors = ['/'.join(path_parts[:i]) for i in range(1, len(path_parts))]
+        paths_to_restore = ['/'.join(path_parts[:i]) for i in range(2, len(path_parts) + 1)]
         runtime_map = {}
 
-        current = history_item.prev
+        current = history_item
         while current:
-            if isinstance(current, CallItem) and current.path in ancestors and current.path not in runtime_map:
+            if isinstance(current, CallItem) and current.path in paths_to_restore and current.path not in runtime_map:
                 runtime_map[current.path] = dict(current.scoped_data)
             current = current.prev
 

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -27,6 +27,7 @@ from rafcon.design_patterns.singleton import Singleton
 from rafcon.design_patterns.observer.observable import Observable
 from rafcon.core.execution.execution_status import ExecutionStatus
 from rafcon.core.execution.execution_status import StateMachineExecutionStatus
+from rafcon.core.execution.execution_history_items import CallItem
 from rafcon.core.config import global_config
 from rafcon.utils import log
 from rafcon.utils import plugins
@@ -299,23 +300,40 @@ class ExecutionEngine(Observable):
     def replay_from_history(self, history_item, state_machine):
         """Execute state machine from a specific point in execution history
 
+        Restores scoped_data for ancestor states only. The target state and its descendants run fresh.
+
         :param history_item: The execution history item to replay from (must be a CallItem)
         :param state_machine: The state machine to execute
         """
+        # Build runtime_map: separate scoped_data for each ancestor path
+        path_parts = history_item.path.split('/')
+        ancestors = ['/'.join(path_parts[:i]) for i in range(1, len(path_parts))]
+        runtime_map = {}
+
+        current = history_item.prev
+        while current:
+            if isinstance(current, CallItem) and current.path in ancestors and current.path not in runtime_map:
+                runtime_map[current.path] = dict(current.scoped_data)
+            current = current.prev
+
         # Build human-readable path from state names
         state = history_item.state_reference
         state_names = []
-        while state and not state.is_root_state:
-            state_names.insert(0, state.name)
+        while not state.is_root_state:
+            if not state.is_root_state_of_library:
+                state_names.insert(0, state.name)
             state = state.parent
-        
+
+        state_names.insert(0, state.name)
+
         human_readable_path = "/".join(state_names)
         logger.info("Replaying execution from {0}".format(human_readable_path))
         logger.debug("Replay state path (IDs): {0}".format(history_item.path))
 
-        # Store scoped data for restoration
+        # Store runtime map for restoration
         self._replay_context = {
-            'scoped_data': dict(history_item.scoped_data)
+            'runtime_map': runtime_map,
+            'target_path': history_item.path
         }
 
         try:

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -305,16 +305,34 @@ class ExecutionEngine(Observable):
         :param history_item: The execution history item to replay from (must be a CallItem)
         :param state_machine: The state machine to execute
         """
-        # Build runtime_map: skip root, include target and ancestors
+        # Build hierarchical list of ancestor state machine paths from selected history item
         path_parts = history_item.path.split('/')
-        paths_to_restore = ['/'.join(path_parts[:i]) for i in range(2, len(path_parts) + 1)]
+        paths_ancestor = ['/'.join(path_parts[:i]) for i in range(1, len(path_parts) + 1)]
+        
+        # Build runtime_map: Save most recent CallItems of each hierarchy by walking
+        # through ancestor in execution history.
         runtime_map = {}
+        current_item = history_item
+        collected_states = []
+        while current_item:
+            # Select relevant items 
+            if isinstance(current_item, CallItem) and \
+                current_item.path in paths_ancestor and \
+                    current_item.path not in collected_states:
+                # Collect most recent CallItem of hierarchy or save it for hierarchy
+                if current_item.call_type_str == 'EXECUTE':
+                    collected_call_item = dict(current_item.scoped_data)
+                    collected_states.append(current_item.path)
+                elif current_item.call_type_str == 'CONTAINER':
+                    # This indicates we are now at the root of the current hierarchy.
+                    # Now save the collected CallItem for this hierarchy.
+                    runtime_map[current_item.path] = collected_call_item
+                else:
+                    raise ValueError(f"Can this case happen? {current_item.call_type_str}")
+            current_item = current_item.prev
 
-        current = history_item
-        while current:
-            if isinstance(current, CallItem) and current.path in paths_to_restore and current.path not in runtime_map:
-                runtime_map[current.path] = dict(current.scoped_data)
-            current = current.prev
+        # -jer continue testing if it works now 
+        # -jer need to pause at the correct state machine
 
         # Build human-readable path from state names
         state = history_item.state_reference

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -328,11 +328,8 @@ class ExecutionEngine(Observable):
                     # Now save the collected CallItem for this hierarchy.
                     runtime_map[current_item.path] = collected_call_item
                 else:
-                    raise ValueError(f"Can this case happen? {current_item.call_type_str}")
+                    raise ValueError(f"Unhandled case for: call_type_str = {current_item.call_type_str}")
             current_item = current_item.prev
-
-        # -jer continue testing if it works now 
-        # -jer need to pause at the correct state machine
 
         # Build human-readable path from state names
         state = history_item.state_reference
@@ -357,9 +354,7 @@ class ExecutionEngine(Observable):
 
         try:
             self.set_start_path(history_item.path)
-            self.state_machine_manager.active_state_machine_id = state_machine.state_machine_id
             self.step_mode(state_machine_id=state_machine.state_machine_id)
-            self.step_into()
         except Exception as e:
             self._replay_context = None
             logger.error("Replay from history failed: {0}".format(e))

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -138,6 +138,10 @@ class ExecutionEngine(Observable):
 
             self.set_execution_mode(StateMachineExecutionStatus.STARTED)
 
+            # Clear replay context on new start
+            if self._replay_context:
+                self._replay_context = None
+
             self.set_start_path(start_state_path)
 
             self._run_active_state_machine()
@@ -291,6 +295,38 @@ class ExecutionEngine(Observable):
             for p in path_list:
                 cur_path = p if cur_path == "" else cur_path + "/" + p
                 self.start_state_paths.append(cur_path)
+
+    def replay_from_history(self, history_item, state_machine):
+        """Execute state machine from a specific point in execution history
+
+        :param history_item: The execution history item to replay from (must be a CallItem)
+        :param state_machine: The state machine to execute
+        """
+        # Build human-readable path from state names
+        state = history_item.state_reference
+        state_names = []
+        while state and not state.is_root_state:
+            state_names.insert(0, state.name)
+            state = state.parent
+        
+        human_readable_path = "/".join(state_names)
+        logger.info("Replaying execution from {0}".format(human_readable_path))
+        logger.debug("Replay state path (IDs): {0}".format(history_item.path))
+
+        # Store scoped data for restoration
+        self._replay_context = {
+            'scoped_data': dict(history_item.scoped_data)
+        }
+
+        try:
+            self.set_start_path(history_item.path)
+            self.state_machine_manager.active_state_machine_id = state_machine.state_machine_id
+            self.step_mode(state_machine_id=state_machine.state_machine_id)
+            self.step_into()
+        except Exception as e:
+            self._replay_context = None
+            logger.error("Replay from history failed: {0}".format(e))
+            raise
 
     def run_to_selected_state(self, path, state_machine_id=None):
         """Execute the state machine until a specific state. This state won't be executed. This is an asynchronous task

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -354,7 +354,10 @@ class ExecutionEngine(Observable):
 
         try:
             self.set_start_path(history_item.path)
-            self.step_mode(state_machine_id=state_machine.state_machine_id)
+            self.state_machine_manager.active_state_machine_id = state_machine.state_machine_id
+            self.set_execution_mode(StateMachineExecutionStatus.RUN_TO_SELECTED_STATE)
+            self.run_to_states = [history_item.path]
+            self._run_active_state_machine()
         except Exception as e:
             self._replay_context = None
             logger.error("Replay from history failed: {0}".format(e))

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -137,17 +137,7 @@ class ExecutionEngine(Observable):
 
             self.set_execution_mode(StateMachineExecutionStatus.STARTED)
 
-            self.start_state_paths = []
-
-            if start_state_path:
-                path_list = start_state_path.split("/")
-                cur_path = ""
-                for path in path_list:
-                    if cur_path == "":
-                        cur_path = path
-                    else:
-                        cur_path = cur_path + "/" + path
-                    self.start_state_paths.append(cur_path)
+            self.set_start_path(start_state_path)
 
             self._run_active_state_machine()
 
@@ -285,6 +275,22 @@ class ExecutionEngine(Observable):
         else:
             self.set_execution_mode(StateMachineExecutionStatus.FORWARD_OUT)
 
+    def set_start_path(self, state_path):
+        """Set the execution start path from a state path string
+
+        Builds the start_state_paths list from the given path by creating
+        the full hierarchical path from root to target state.
+
+        :param state_path: Path to the state to start from (e.g., "ROOT/CONTAINER/STATE")
+        """
+        self.start_state_paths = []
+        if state_path:
+            path_list = state_path.split("/")
+            cur_path = ""
+            for p in path_list:
+                cur_path = p if cur_path == "" else cur_path + "/" + p
+                self.start_state_paths.append(cur_path)
+
     def run_to_selected_state(self, path, state_machine_id=None):
         """Execute the state machine until a specific state. This state won't be executed. This is an asynchronous task
         """
@@ -326,20 +332,18 @@ class ExecutionEngine(Observable):
 
         self.run_to_states = []
         # set appropriate start states
-        self.start_state_paths = []
+        self.set_start_path(start_state_path)
+
+        # Truncate path at parent concurrency state if needed
         if start_state_path:
             path_list = start_state_path.split("/")
-            cur_path = ""
-            for path in path_list:
-                if cur_path == "":
-                    cur_path = path
-                else:
-                    cur_path = cur_path + "/" + path
-                self.start_state_paths.append(cur_path)
+            for i, path in enumerate(path_list):
                 if path == parent_concurrency_id:
+                    self.start_state_paths = self.start_state_paths[:i+1]
                     break
 
         # set target states when execution should stop
+        cur_path = self.start_state_paths[-1] if self.start_state_paths else ""
         self.run_to_states.append(cur_path)
 
     def run_selected_state(self, start_state_path=None, state_machine_id=None):

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -27,7 +27,7 @@ from rafcon.design_patterns.singleton import Singleton
 from rafcon.design_patterns.observer.observable import Observable
 from rafcon.core.execution.execution_status import ExecutionStatus
 from rafcon.core.execution.execution_status import StateMachineExecutionStatus
-from rafcon.core.execution.execution_history_items import CallItem
+from rafcon.core.execution.execution_history_items import CallItem, ReturnItem
 from rafcon.core.config import global_config
 from rafcon.utils import log
 from rafcon.utils import plugins
@@ -346,10 +346,26 @@ class ExecutionEngine(Observable):
         logger.info('Replaying execution from "{0}"'.format(human_readable_path))
         logger.debug('Replay state path (IDs): {0}'.format(history_item.path))
 
+        # Find the state that executed just before the selected state by walking back in history
+        previous_state_path = None
+        prev_item = history_item.prev
+        target_path_parts = history_item.path.split('/')
+        while prev_item:
+            # Look for a ReturnItem (state completion) that represents a sibling state
+            if isinstance(prev_item, ReturnItem):
+                prev_path_parts = prev_item.path.split('/')
+                # Check if this is a sibling (same parent) by comparing path depths
+                if len(prev_path_parts) == len(target_path_parts) and \
+                   prev_path_parts[:-1] == target_path_parts[:-1]:
+                    previous_state_path = prev_item.path
+                    break
+            prev_item = prev_item.prev
+
         # Store runtime map for restoration
         self._replay_context = {
             'runtime_map': runtime_map,
-            'target_path': history_item.path
+            'target_path': history_item.path,
+            'previous_state_path': previous_state_path
         }
 
         try:

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -67,6 +67,7 @@ class ExecutionEngine(Observable):
         self.new_execution_command_handled = True
         self.stop_state_machine_after_finishing_step = False
         self.running_only_selected_state = False
+        self._replay_context = None
 
     @Observable.observed
     def pause(self):

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -320,6 +320,7 @@ class ExecutionEngine(Observable):
         state = history_item.state_reference
         state_names = []
         while not state.is_root_state:
+            # skip root state of library state to omit name duplication in path
             if not state.is_root_state_of_library:
                 state_names.insert(0, state.name)
             state = state.parent
@@ -327,8 +328,8 @@ class ExecutionEngine(Observable):
         state_names.insert(0, state.name)
 
         human_readable_path = "/".join(state_names)
-        logger.info("Replaying execution from {0}".format(human_readable_path))
-        logger.debug("Replay state path (IDs): {0}".format(history_item.path))
+        logger.info('Replaying execution from "{0}"'.format(human_readable_path))
+        logger.debug('Replay state path (IDs): {0}'.format(history_item.path))
 
         # Store runtime map for restoration
         self._replay_context = {

--- a/source/rafcon/core/execution/execution_engine.py
+++ b/source/rafcon/core/execution/execution_engine.py
@@ -356,7 +356,7 @@ class ExecutionEngine(Observable):
                 prev_path_parts = prev_item.path.split('/')
                 # Check if this is a sibling (same parent) by comparing path depths
                 if len(prev_path_parts) == len(target_path_parts) and \
-                   prev_path_parts[:-1] == target_path_parts[:-1]:
+                    prev_path_parts[:-1] == target_path_parts[:-1]:
                     previous_state_path = prev_item.path
                     break
             prev_item = prev_item.prev

--- a/source/rafcon/core/states/container_state.py
+++ b/source/rafcon/core/states/container_state.py
@@ -1099,6 +1099,23 @@ class ContainerState(State):
         else:
             self.start_state_id = state
 
+    def _find_previous_state_for(self, target_state):
+        """Find the state that transitions to the target state
+
+        :param target_state: The state to find the predecessor for
+        :return: The state that comes before target_state in execution order, or None
+        """
+        # Look through all transitions to find which state transitions to the target
+        for transition_id, transition in self.transitions.items():
+            # Check if this transition goes to the target state
+            if transition.to_state == target_state.state_id:
+                # Found a transition to the target, get the FROM state
+                if transition.from_state is not None:
+                    from_state_id = transition.from_state
+                    if from_state_id in self.states:
+                        return self.states[from_state_id]
+        return None
+
     def get_start_state(self, set_final_outcome=False):
         """Get the start state of the container state
 
@@ -1106,13 +1123,20 @@ class ContainerState(State):
                                     an outcome
         :return: the start state
         """
-
         # overwrite the start state in the case that a specific start state is specific e.g. by start_from_state
         if self.get_path() in state_machine_execution_engine.start_state_paths:
             for state_id, state in self.states.items():
                 if state.get_path() in state_machine_execution_engine.start_state_paths:
                     state_machine_execution_engine.start_state_paths.remove(self.get_path())
                     self._start_state_modified = True
+
+                    # Find the previous state in the transition chain
+                    # This gives the yellow border to the correct state (the one before target)
+                    previous_state = self._find_previous_state_for(state)
+                    if previous_state:
+                        previous_state.state_execution_status = StateExecutionStatus.WAIT_FOR_NEXT_STATE
+                        self.last_child = previous_state
+
                     return state
 
         if self.start_state_id is None:

--- a/source/rafcon/core/states/container_state.py
+++ b/source/rafcon/core/states/container_state.py
@@ -285,15 +285,10 @@ class ContainerState(State):
             return
 
         state_path = self.get_path()
-        target_path = replay_ctx['target_path']
-
-        # Don't restore for states at or below the target (descendants should run fresh)
-        if state_path == target_path or state_path.startswith(target_path + "/"):
-            return
-
         runtime_map = replay_ctx['runtime_map']
         if state_path in runtime_map:
             self._scoped_data.update(runtime_map[state_path])
+            del runtime_map[state_path]
 
     def handle_no_transition(self, state):
         """ This function handles the case that there is no transition for a specific outcome of a sub-state.

--- a/source/rafcon/core/states/container_state.py
+++ b/source/rafcon/core/states/container_state.py
@@ -280,11 +280,20 @@ class ContainerState(State):
 
     def _restore_replay_context(self):
         """Restore scoped data from execution history replay context if available"""
-        from rafcon.core.singleton import state_machine_execution_engine
-        if state_machine_execution_engine._replay_context:
-            scoped_data = state_machine_execution_engine._replay_context.get('scoped_data')
-            if scoped_data:
-                self._scoped_data.update(scoped_data)
+        replay_ctx = state_machine_execution_engine._replay_context
+        if not replay_ctx:
+            return
+
+        state_path = self.get_path()
+        target_path = replay_ctx['target_path']
+
+        # Don't restore for states at or below the target (descendants should run fresh)
+        if state_path == target_path or state_path.startswith(target_path + "/"):
+            return
+
+        runtime_map = replay_ctx['runtime_map']
+        if state_path in runtime_map:
+            self._scoped_data.update(runtime_map[state_path])
 
     def handle_no_transition(self, state):
         """ This function handles the case that there is no transition for a specific outcome of a sub-state.

--- a/source/rafcon/core/states/container_state.py
+++ b/source/rafcon/core/states/container_state.py
@@ -276,6 +276,15 @@ class ContainerState(State):
         self._start_state_modified = False
         self.add_default_values_of_scoped_variables_to_scoped_data()
         self.add_input_data_to_scoped_data(self.input_data)
+        self._restore_replay_context()
+
+    def _restore_replay_context(self):
+        """Restore scoped data from execution history replay context if available"""
+        from rafcon.core.singleton import state_machine_execution_engine
+        if state_machine_execution_engine._replay_context:
+            scoped_data = state_machine_execution_engine._replay_context.get('scoped_data')
+            if scoped_data:
+                self._scoped_data.update(scoped_data)
 
     def handle_no_transition(self, state):
         """ This function handles the case that there is no transition for a specific outcome of a sub-state.

--- a/source/rafcon/core/states/container_state.py
+++ b/source/rafcon/core/states/container_state.py
@@ -289,6 +289,8 @@ class ContainerState(State):
         if state_path in runtime_map:
             self._scoped_data.update(runtime_map[state_path])
             del runtime_map[state_path]
+            # Save previous_state_path before context may be cleared
+            self._replay_previous_state_path = replay_ctx.get('previous_state_path')
             if not runtime_map:
                 state_machine_execution_engine._replay_context = None
 
@@ -1099,23 +1101,6 @@ class ContainerState(State):
         else:
             self.start_state_id = state
 
-    def _find_previous_state_for(self, target_state):
-        """Find the state that transitions to the target state
-
-        :param target_state: The state to find the predecessor for
-        :return: The state that comes before target_state in execution order, or None
-        """
-        # Look through all transitions to find which state transitions to the target
-        for transition_id, transition in self.transitions.items():
-            # Check if this transition goes to the target state
-            if transition.to_state == target_state.state_id:
-                # Found a transition to the target, get the FROM state
-                if transition.from_state is not None:
-                    from_state_id = transition.from_state
-                    if from_state_id in self.states:
-                        return self.states[from_state_id]
-        return None
-
     def get_start_state(self, set_final_outcome=False):
         """Get the start state of the container state
 
@@ -1130,12 +1115,15 @@ class ContainerState(State):
                     state_machine_execution_engine.start_state_paths.remove(self.get_path())
                     self._start_state_modified = True
 
-                    # Find the previous state in the transition chain
-                    # This gives the yellow border to the correct state (the one before target)
-                    previous_state = self._find_previous_state_for(state)
-                    if previous_state:
-                        previous_state.state_execution_status = StateExecutionStatus.WAIT_FOR_NEXT_STATE
-                        self.last_child = previous_state
+                    # Highlight the previous state from execution history replay
+                    previous_state_path = getattr(self, '_replay_previous_state_path', None)
+                    if previous_state_path:
+                        previous_state_id = previous_state_path.split('/')[-1]
+                        if previous_state_id in self.states:
+                            previous_state = self.states[previous_state_id]
+                            previous_state.state_execution_status = StateExecutionStatus.WAIT_FOR_NEXT_STATE
+                            self.last_child = previous_state
+                        self._replay_previous_state_path = None
 
                     return state
 

--- a/source/rafcon/core/states/container_state.py
+++ b/source/rafcon/core/states/container_state.py
@@ -290,7 +290,7 @@ class ContainerState(State):
             self._scoped_data.update(runtime_map[state_path])
             del runtime_map[state_path]
             if not runtime_map:
-                replay_ctx = None
+                state_machine_execution_engine._replay_context = None
 
     def handle_no_transition(self, state):
         """ This function handles the case that there is no transition for a specific outcome of a sub-state.

--- a/source/rafcon/core/states/container_state.py
+++ b/source/rafcon/core/states/container_state.py
@@ -289,6 +289,8 @@ class ContainerState(State):
         if state_path in runtime_map:
             self._scoped_data.update(runtime_map[state_path])
             del runtime_map[state_path]
+            if not runtime_map:
+                replay_ctx = None
 
     def handle_no_transition(self, state):
         """ This function handles the case that there is no transition for a specific outcome of a sub-state.

--- a/source/rafcon/gui/controllers/execution_history.py
+++ b/source/rafcon/gui/controllers/execution_history.py
@@ -306,10 +306,45 @@ class ExecutionHistoryTreeController(ExtendedController):
                         self.append_string_to_menu(popup_menu, final_outcome_menu_item_string)
                         self.append_string_to_menu(popup_menu, "------------------------")
 
+                # Add "Start From Here" menu item for CallItem
+                if isinstance(history_item, CallItem):
+                    separator = Gtk.SeparatorMenuItem()
+                    separator.show()
+                    popup_menu.append(separator)
+
+                    menu_item = Gtk.MenuItem("Start From Here")
+                    menu_item.connect("activate", lambda w: self._on_start_from_here(history_item))
+                    menu_item.show()
+                    popup_menu.append(menu_item)
+
                 popup_menu.show()
                 popup_menu.popup(None, None, None, None, event.get_button()[1], time)
 
             return True
+
+    def _on_start_from_here(self, history_item):
+        """Handle 'Start From Here' menu action
+        
+        :param history_item: The history item to start execution from
+        """
+        if not state_machine_execution_engine.finished_or_stopped():
+            logger.warning("Cannot start from here while execution is running")
+            return
+
+        # Get the state machine
+        if self.lock_view_flag:
+            state_machine = self.lock_state_machine_model.state_machine
+        else:
+            sm_m = self.model.get_selected_state_machine_model()
+            if not sm_m:
+                logger.warning("No state machine selected")
+                return
+            state_machine = sm_m.state_machine
+
+        try:
+            state_machine_execution_engine.replay_from_history(history_item, state_machine)
+        except Exception as e:
+            logger.warning("Start from here failed: {0}".format(e))
 
     def get_history_item_for_tree_iter(self, child_tree_iter):
         """Hands history item for tree iter and compensate if tree item is a dummy item

--- a/source/rafcon/gui/controllers/execution_history.py
+++ b/source/rafcon/gui/controllers/execution_history.py
@@ -306,8 +306,8 @@ class ExecutionHistoryTreeController(ExtendedController):
                         self.append_string_to_menu(popup_menu, final_outcome_menu_item_string)
                         self.append_string_to_menu(popup_menu, "------------------------")
 
-                # Add "Start From Here" menu item for CallItem
-                if isinstance(history_item, CallItem):
+                # Add "Start From Here" menu item for CallItem and type 'EXECUTE'
+                if isinstance(history_item, CallItem) and history_item.call_type_str == 'EXECUTE':
                     separator = Gtk.SeparatorMenuItem()
                     separator.show()
                     popup_menu.append(separator)

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/core_data.json
@@ -1,0 +1,28 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "configure camera", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "VVHWKH"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(0.2)
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/script.py
@@ -1,5 +1,3 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(0.2)
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_camera/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:50:12", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/core_data.json
@@ -1,0 +1,28 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "configure world", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "VVHWKH"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/script.py
@@ -1,5 +1,3 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(0.5)
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(0.5)
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/configure_world/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:50:12", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_1/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_1/core_data.json
@@ -1,0 +1,48 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_0"
+        }
+    }, 
+    "name": "example interface 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "state_id": "PHPOHQ"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_1/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_1/script.py
@@ -1,0 +1,4 @@
+
+def execute(self, inputs, outputs, gvm):
+    outputs["output_1"] = inputs["input_0"]
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_1/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_1/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:07:16", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_2/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_2/core_data.json
@@ -1,0 +1,48 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_0"
+        }
+    }, 
+    "name": "example interface 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "state_id": "PHPOHQ"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_2/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_2/script.py
@@ -1,0 +1,4 @@
+
+def execute(self, inputs, outputs, gvm):
+    outputs["output_1"] = inputs["input_0"] + 1
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_2/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_interface_2/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:07:16", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/core_data.json
@@ -1,0 +1,168 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 2, 
+            "from_key": 0, 
+            "from_state": "TBZGPV", 
+            "to_key": 0, 
+            "to_state": "NJWRGI"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 3, 
+            "from_key": 2, 
+            "from_state": "TBZGPV", 
+            "to_key": 1, 
+            "to_state": "NJWRGI"
+        }, 
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 4, 
+            "from_key": 2, 
+            "from_state": "NJWRGI", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 5, 
+            "from_key": 3, 
+            "from_state": "NJWRGI", 
+            "to_key": 1, 
+            "to_state": "TBZGPV"
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 6, 
+            "from_key": 2, 
+            "from_state": "TBZGPV", 
+            "to_key": 1, 
+            "to_state": "WGARAD"
+        }, 
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 7, 
+            "from_key": 4, 
+            "from_state": "NJWRGI", 
+            "to_key": 0, 
+            "to_state": "WGARAD"
+        }, 
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 8, 
+            "from_key": 2, 
+            "from_state": "WGARAD", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 9, 
+            "from_key": 2, 
+            "from_state": "UKYXAQ", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 2, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_from_outside"
+        }
+    }, 
+    "name": "example set some data 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 3, 
+            "data_type": {
+                "__type__": "__builtin__.str"
+            }, 
+            "default_value": null, 
+            "name": "output_from_inside"
+        }
+    }, 
+    "scoped_variables": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.scope.ScopedVariable", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": 0, 
+            "name": "scoped_0"
+        }, 
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.scope.ScopedVariable", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.list"
+            }, 
+            "default_value": [], 
+            "name": "scoped_1"
+        }
+    }, 
+    "state_id": "TBZGPV", 
+    "transitions": {
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "NJWRGI", 
+            "transition_id": 9
+        }, 
+        "10": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NJWRGI", 
+            "to_outcome": null, 
+            "to_state": "UKYXAQ", 
+            "transition_id": 10
+        }, 
+        "11": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "UKYXAQ", 
+            "to_outcome": null, 
+            "to_state": "WGARAD", 
+            "transition_id": 11
+        }, 
+        "12": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "WGARAD", 
+            "to_outcome": 0, 
+            "to_state": "TBZGPV", 
+            "transition_id": 12
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/execution_state_1_NJWRGI/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/execution_state_1_NJWRGI/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null, 
+        "1": null
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "NJWRGI", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/execution_state_2_UKYXAQ/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/execution_state_2_UKYXAQ/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": 42, 
+        "1": 45
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "UKYXAQ", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/execution_state_3_WGARAD/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/execution_state_3_WGARAD/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": 3, 
+        "1": 5
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 3", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "WGARAD", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:58:57", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/ExecutionState_3_NAYMSQ/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/ExecutionState_3_NAYMSQ/core_data.json
@@ -1,0 +1,57 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": 0, 
+            "name": "scoped_0"
+        }, 
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.list"
+            }, 
+            "default_value": [], 
+            "name": "scoped_1"
+        }
+    }, 
+    "name": "ExecutionState 3", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 2, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": 67, 
+            "name": "output_2"
+        }
+    }, 
+    "state_id": "NAYMSQ"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/ExecutionState_3_NAYMSQ/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/ExecutionState_3_NAYMSQ/script.py
@@ -1,6 +1,4 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(1)
     outputs["output_2"] = 44
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/ExecutionState_3_NAYMSQ/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/ExecutionState_3_NAYMSQ/script.py
@@ -1,0 +1,6 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(1)
+    outputs["output_2"] = 44
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/core_data.json
@@ -1,0 +1,208 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 2, 
+            "from_key": 0, 
+            "from_state": "TBZGPV", 
+            "to_key": 0, 
+            "to_state": "NJWRGI"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 3, 
+            "from_key": 2, 
+            "from_state": "TBZGPV", 
+            "to_key": 1, 
+            "to_state": "NJWRGI"
+        }, 
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 4, 
+            "from_key": 2, 
+            "from_state": "NJWRGI", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 5, 
+            "from_key": 3, 
+            "from_state": "NJWRGI", 
+            "to_key": 1, 
+            "to_state": "TBZGPV"
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 6, 
+            "from_key": 2, 
+            "from_state": "TBZGPV", 
+            "to_key": 1, 
+            "to_state": "WGARAD"
+        }, 
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 7, 
+            "from_key": 4, 
+            "from_state": "NJWRGI", 
+            "to_key": 0, 
+            "to_state": "WGARAD"
+        }, 
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 8, 
+            "from_key": 2, 
+            "from_state": "WGARAD", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 9, 
+            "from_key": 2, 
+            "from_state": "UKYXAQ", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }, 
+        "10": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 10, 
+            "from_key": 0, 
+            "from_state": "TBZGPV", 
+            "to_key": 0, 
+            "to_state": "NAYMSQ"
+        }, 
+        "11": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 11, 
+            "from_key": 1, 
+            "from_state": "TBZGPV", 
+            "to_key": 1, 
+            "to_state": "NAYMSQ"
+        }, 
+        "12": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 12, 
+            "from_key": 2, 
+            "from_state": "NAYMSQ", 
+            "to_key": 0, 
+            "to_state": "UKYXAQ"
+        }, 
+        "13": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 13, 
+            "from_key": 2, 
+            "from_state": "NAYMSQ", 
+            "to_key": 0, 
+            "to_state": "TBZGPV"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 2, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_from_outside"
+        }
+    }, 
+    "name": "example set some data 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 3, 
+            "data_type": {
+                "__type__": "__builtin__.str"
+            }, 
+            "default_value": null, 
+            "name": "output_from_inside"
+        }
+    }, 
+    "scoped_variables": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.scope.ScopedVariable", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": 0, 
+            "name": "scoped_0"
+        }, 
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.scope.ScopedVariable", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.list"
+            }, 
+            "default_value": [], 
+            "name": "scoped_1"
+        }
+    }, 
+    "state_id": "TBZGPV", 
+    "transitions": {
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "NJWRGI", 
+            "transition_id": 9
+        }, 
+        "11": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "UKYXAQ", 
+            "to_outcome": null, 
+            "to_state": "WGARAD", 
+            "transition_id": 11
+        }, 
+        "12": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "WGARAD", 
+            "to_outcome": 0, 
+            "to_state": "TBZGPV", 
+            "transition_id": 12
+        }, 
+        "14": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NJWRGI", 
+            "to_outcome": null, 
+            "to_state": "NAYMSQ", 
+            "transition_id": 14
+        }, 
+        "15": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NAYMSQ", 
+            "to_outcome": null, 
+            "to_state": "UKYXAQ", 
+            "transition_id": 15
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/execution_state_1_NJWRGI/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/execution_state_1_NJWRGI/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null, 
+        "1": null
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "NJWRGI", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/execution_state_2_UKYXAQ/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/execution_state_2_UKYXAQ/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": 42, 
+        "1": 45
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "UKYXAQ", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/execution_state_3_WGARAD/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/execution_state_3_WGARAD/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": 3, 
+        "1": 5
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 3", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "WGARAD", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_set_some_data_2/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:58:57", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/core_data.json
@@ -1,0 +1,64 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {}, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "example initialize", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "scoped_variables": {}, 
+    "state_id": "OBMPWF", 
+    "transitions": {
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "MSDBRU", 
+            "transition_id": 4
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "MSDBRU", 
+            "to_outcome": null, 
+            "to_state": "ELDETN", 
+            "transition_id": 5
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "ELDETN", 
+            "to_outcome": null, 
+            "to_state": "NPMEBW", 
+            "transition_id": 6
+        }, 
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NPMEBW", 
+            "to_outcome": 0, 
+            "to_state": "OBMPWF", 
+            "transition_id": 7
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/init_ros2_node_NPMEBW/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/init_ros2_node_NPMEBW/core_data.json
@@ -1,0 +1,29 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {}, 
+    "library_name": "init_ros2_node", 
+    "library_path": "develop_test", 
+    "name": "init ros2 node", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {}, 
+    "state_id": "NPMEBW", 
+    "use_runtime_value_input_data_ports": {}, 
+    "use_runtime_value_output_data_ports": {}, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/initialize_camera_MSDBRU/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/initialize_camera_MSDBRU/core_data.json
@@ -1,0 +1,29 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {}, 
+    "library_name": "initialize_camera", 
+    "library_path": "develop_test", 
+    "name": "initialize camera", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {}, 
+    "state_id": "MSDBRU", 
+    "use_runtime_value_input_data_ports": {}, 
+    "use_runtime_value_output_data_ports": {}, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/initialize_world_ELDETN/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/initialize_world_ELDETN/core_data.json
@@ -1,0 +1,29 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {}, 
+    "library_name": "initialize_world", 
+    "library_path": "develop_test", 
+    "name": "initialize world", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {}, 
+    "state_id": "ELDETN", 
+    "use_runtime_value_input_data_ports": {}, 
+    "use_runtime_value_output_data_ports": {}, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_initialize/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:48:28", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/core_data.json
@@ -1,0 +1,168 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 2, 
+            "from_key": 0, 
+            "from_state": "TBZGPV", 
+            "to_key": 0, 
+            "to_state": "NJWRGI"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 3, 
+            "from_key": 2, 
+            "from_state": "TBZGPV", 
+            "to_key": 1, 
+            "to_state": "NJWRGI"
+        }, 
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 4, 
+            "from_key": 2, 
+            "from_state": "NJWRGI", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 5, 
+            "from_key": 3, 
+            "from_state": "NJWRGI", 
+            "to_key": 1, 
+            "to_state": "TBZGPV"
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 6, 
+            "from_key": 2, 
+            "from_state": "TBZGPV", 
+            "to_key": 1, 
+            "to_state": "WGARAD"
+        }, 
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 7, 
+            "from_key": 4, 
+            "from_state": "NJWRGI", 
+            "to_key": 0, 
+            "to_state": "WGARAD"
+        }, 
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 8, 
+            "from_key": 2, 
+            "from_state": "WGARAD", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 9, 
+            "from_key": 2, 
+            "from_state": "UKYXAQ", 
+            "to_key": 3, 
+            "to_state": "TBZGPV"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 2, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_from_outside"
+        }
+    }, 
+    "name": "example set some data 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 3, 
+            "data_type": {
+                "__type__": "__builtin__.str"
+            }, 
+            "default_value": null, 
+            "name": "output_from_inside"
+        }
+    }, 
+    "scoped_variables": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.scope.ScopedVariable", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": 0, 
+            "name": "scoped_0"
+        }, 
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.scope.ScopedVariable", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.list"
+            }, 
+            "default_value": [], 
+            "name": "scoped_1"
+        }
+    }, 
+    "state_id": "TBZGPV", 
+    "transitions": {
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "NJWRGI", 
+            "transition_id": 9
+        }, 
+        "10": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NJWRGI", 
+            "to_outcome": null, 
+            "to_state": "UKYXAQ", 
+            "transition_id": 10
+        }, 
+        "11": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "UKYXAQ", 
+            "to_outcome": null, 
+            "to_state": "WGARAD", 
+            "transition_id": 11
+        }, 
+        "12": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "WGARAD", 
+            "to_outcome": 0, 
+            "to_state": "TBZGPV", 
+            "transition_id": 12
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/execution_state_1_NJWRGI/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/execution_state_1_NJWRGI/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null, 
+        "1": null
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "NJWRGI", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/execution_state_2_UKYXAQ/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/execution_state_2_UKYXAQ/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": 42, 
+        "1": 45
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "UKYXAQ", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/execution_state_3_WGARAD/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/execution_state_3_WGARAD/core_data.json
@@ -1,0 +1,43 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": 3, 
+        "1": 5
+    }, 
+    "library_name": "execution_state", 
+    "library_path": "develop_test", 
+    "name": "execution state 3", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null, 
+        "3": [], 
+        "4": null
+    }, 
+    "state_id": "WGARAD", 
+    "use_runtime_value_input_data_ports": {
+        "0": true, 
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true, 
+        "3": true, 
+        "4": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/example_set_some_data/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:58:57", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/Decider_unique_decider_state_id/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/Decider_unique_decider_state_id/core_data.json
@@ -1,0 +1,28 @@
+{
+    "__jsonqualname__": "rafcon.core.states.barrier_concurrency_state.DeciderState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "Decider", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "unique_decider_state_id"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/Decider_unique_decider_state_id/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/Decider_unique_decider_state_id/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(2)
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/Decider_unique_decider_state_id/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/Decider_unique_decider_state_id/script.py
@@ -1,5 +1,3 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(2)
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/core_data.json
@@ -1,0 +1,56 @@
+{
+    "__jsonqualname__": "rafcon.core.states.barrier_concurrency_state.BarrierConcurrencyState", 
+    "data_flows": {}, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "BarrierConcurrencyState 4", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "scoped_variables": {}, 
+    "state_id": "KEQYNU", 
+    "transitions": {
+        "16": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "unique_decider_state_id", 
+            "to_outcome": 0, 
+            "to_state": "KEQYNU", 
+            "transition_id": 16
+        }, 
+        "17": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "YZOSOB", 
+            "to_outcome": null, 
+            "to_state": "unique_decider_state_id", 
+            "transition_id": 17
+        }, 
+        "18": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "ACTYCW", 
+            "to_outcome": null, 
+            "to_state": "unique_decider_state_id", 
+            "transition_id": 18
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/example_set_some_data_2_ACTYCW/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/example_set_some_data_2_ACTYCW/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "2": null
+    }, 
+    "library_name": "example_set_some_data_2", 
+    "library_path": "develop_test", 
+    "name": "example set some data 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "3": null
+    }, 
+    "state_id": "ACTYCW", 
+    "use_runtime_value_input_data_ports": {
+        "2": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "3": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/example_set_some_data_YZOSOB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/BarrierConcurrencyState_4_KEQYNU/example_set_some_data_YZOSOB/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "2": null
+    }, 
+    "library_name": "example_set_some_data", 
+    "library_path": "develop_test", 
+    "name": "example set some data", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "3": null
+    }, 
+    "state_id": "YZOSOB", 
+    "use_runtime_value_input_data_ports": {
+        "2": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "3": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/ExecutionState_6_GITGSG/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/ExecutionState_6_GITGSG/core_data.json
@@ -1,0 +1,66 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": 0, 
+            "name": "scoped_0"
+        }, 
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "ExecutionState 6", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 2, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 3, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "scoped_0"
+        }
+    }, 
+    "state_id": "GITGSG"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/ExecutionState_6_GITGSG/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/ExecutionState_6_GITGSG/script.py
@@ -1,6 +1,5 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
     outputs["output_1"] = inputs["input_1"] + 1
     outputs["scoped_0"] = inputs["scoped_0"] + 1
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/ExecutionState_6_GITGSG/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/ExecutionState_6_GITGSG/script.py
@@ -1,0 +1,6 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    outputs["output_1"] = inputs["input_1"] + 1
+    outputs["scoped_0"] = inputs["scoped_0"] + 1
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/PreemptiveConcurrencyState_5_AESIQF/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/PreemptiveConcurrencyState_5_AESIQF/core_data.json
@@ -1,0 +1,48 @@
+{
+    "__jsonqualname__": "rafcon.core.states.preemptive_concurrency_state.PreemptiveConcurrencyState", 
+    "data_flows": {}, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "PreemptiveConcurrencyState 5", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "scoped_variables": {}, 
+    "state_id": "AESIQF", 
+    "transitions": {
+        "22": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "LNQSPL", 
+            "to_outcome": 0, 
+            "to_state": "AESIQF", 
+            "transition_id": 22
+        }, 
+        "23": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "GRGRHF", 
+            "to_outcome": 0, 
+            "to_state": "AESIQF", 
+            "transition_id": 23
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/PreemptiveConcurrencyState_5_AESIQF/example_set_some_data_2_LNQSPL/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/PreemptiveConcurrencyState_5_AESIQF/example_set_some_data_2_LNQSPL/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "2": null
+    }, 
+    "library_name": "example_set_some_data_2", 
+    "library_path": "develop_test", 
+    "name": "example set some data 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "3": null
+    }, 
+    "state_id": "LNQSPL", 
+    "use_runtime_value_input_data_ports": {
+        "2": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "3": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/PreemptiveConcurrencyState_5_AESIQF/example_set_some_data_GRGRHF/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/PreemptiveConcurrencyState_5_AESIQF/example_set_some_data_GRGRHF/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "2": null
+    }, 
+    "library_name": "example_set_some_data", 
+    "library_path": "develop_test", 
+    "name": "example set some data", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "3": null
+    }, 
+    "state_id": "GRGRHF", 
+    "use_runtime_value_input_data_ports": {
+        "2": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "3": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/core_data.json
@@ -1,0 +1,127 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "14": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 14, 
+            "from_key": 0, 
+            "from_state": "LZLXFW", 
+            "to_key": 0, 
+            "to_state": "GITGSG"
+        }, 
+        "15": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 15, 
+            "from_key": 1, 
+            "from_state": "LZLXFW", 
+            "to_key": 1, 
+            "to_state": "GITGSG"
+        }, 
+        "16": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 16, 
+            "from_key": 3, 
+            "from_state": "GITGSG", 
+            "to_key": 0, 
+            "to_state": "LZLXFW"
+        }, 
+        "17": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 17, 
+            "from_key": 2, 
+            "from_state": "GITGSG", 
+            "to_key": 2, 
+            "to_state": "LZLXFW"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "task 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 2, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.scope.ScopedVariable", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": 0, 
+            "name": "scoped_0"
+        }
+    }, 
+    "state_id": "LZLXFW", 
+    "transitions": {
+        "20": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "KEQYNU", 
+            "transition_id": 20
+        }, 
+        "25": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "AESIQF", 
+            "to_outcome": 0, 
+            "to_state": "LZLXFW", 
+            "transition_id": 25
+        }, 
+        "26": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "KEQYNU", 
+            "to_outcome": null, 
+            "to_state": "GITGSG", 
+            "transition_id": 26
+        }, 
+        "27": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "GITGSG", 
+            "to_outcome": null, 
+            "to_state": "AESIQF", 
+            "transition_id": 27
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_1/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:10:49", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/core_data.json
@@ -1,0 +1,117 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "18": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 18, 
+            "from_key": 0, 
+            "from_state": "EAWGCM", 
+            "to_key": 1, 
+            "to_state": "SFSEDE"
+        }, 
+        "19": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 19, 
+            "from_key": 0, 
+            "from_state": "SFSEDE", 
+            "to_key": 1, 
+            "to_state": "VLXMXE"
+        }, 
+        "20": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 20, 
+            "from_key": 0, 
+            "from_state": "VLXMXE", 
+            "to_key": 1, 
+            "to_state": "EHNGJB"
+        }, 
+        "21": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 21, 
+            "from_key": 0, 
+            "from_state": "EHNGJB", 
+            "to_key": 1, 
+            "to_state": "EAWGCM"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_0"
+        }
+    }, 
+    "name": "task 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "EAWGCM", 
+    "transitions": {
+        "26": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "SFSEDE", 
+            "transition_id": 26
+        }, 
+        "27": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "SFSEDE", 
+            "to_outcome": null, 
+            "to_state": "VLXMXE", 
+            "transition_id": 27
+        }, 
+        "28": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "VLXMXE", 
+            "to_outcome": null, 
+            "to_state": "EHNGJB", 
+            "transition_id": 28
+        }, 
+        "29": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "EHNGJB", 
+            "to_outcome": 0, 
+            "to_state": "EAWGCM", 
+            "transition_id": 29
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/hierarchy_2_EHNGJB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/hierarchy_2_EHNGJB/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_2", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "EHNGJB", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/hierarchy_2_SFSEDE/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/hierarchy_2_SFSEDE/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_2", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "SFSEDE", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/hierarchy_2_VLXMXE/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/hierarchy_2_VLXMXE/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_2", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "VLXMXE", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/example_state_machines/task_2/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:31:04", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/core_data.json
@@ -1,0 +1,75 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_0"
+        }, 
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "execution state", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 2, 
+            "data_type": {
+                "__type__": "__builtin__.str"
+            }, 
+            "default_value": null, 
+            "name": "output_2"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 3, 
+            "data_type": {
+                "__type__": "__builtin__.list"
+            }, 
+            "default_value": [], 
+            "name": "output_3"
+        }, 
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 4, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_4"
+        }
+    }, 
+    "state_id": "XQMIFP"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/script.py
@@ -1,7 +1,5 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(0.1)
     outputs["output_2"] = "some manual output"
     outputs["output_3"] = [0, 1, 2, 3, 4]
     outputs["output_4"] = 7

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/script.py
@@ -1,0 +1,8 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(0.1)
+    outputs["output_2"] = "some manual output"
+    outputs["output_3"] = [0, 1, 2, 3, 4]
+    outputs["output_4"] = 7
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/execution_state/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:58:18", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/ExecutionState_1_AQCUHE/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/ExecutionState_1_AQCUHE/core_data.json
@@ -1,0 +1,28 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "ExecutionState 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "AQCUHE"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/ExecutionState_1_AQCUHE/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/ExecutionState_1_AQCUHE/script.py
@@ -1,0 +1,6 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(0.4)
+    gvm.set_variable("gvm_set", True)
+    return "success" 

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/ExecutionState_1_AQCUHE/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/ExecutionState_1_AQCUHE/script.py
@@ -1,6 +1,4 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(0.4)
     gvm.set_variable("gvm_set", True)
     return "success" 

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/core_data.json
@@ -1,0 +1,109 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 1, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 0, 
+            "to_state": "BNLTCG"
+        }, 
+        "13": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 13, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 0, 
+            "to_state": "USFTMR"
+        }, 
+        "17": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 17, 
+            "from_key": 1, 
+            "from_state": "USFTMR", 
+            "to_key": 0, 
+            "to_state": "MQRVHE"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "MQRVHE", 
+    "transitions": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "USFTMR", 
+            "to_outcome": null, 
+            "to_state": "AQCUHE", 
+            "transition_id": 1
+        }, 
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "AQCUHE", 
+            "to_outcome": 0, 
+            "to_state": "MQRVHE", 
+            "transition_id": 2
+        }, 
+        "16": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "BNLTCG", 
+            "to_outcome": null, 
+            "to_state": "USFTMR", 
+            "transition_id": 16
+        }, 
+        "23": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "BNLTCG", 
+            "transition_id": 23
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_BNLTCG/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_BNLTCG/core_data.json
@@ -1,0 +1,67 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 3, 
+            "from_key": 0, 
+            "from_state": "BNLTCG", 
+            "to_key": 1, 
+            "to_state": "IKAANM"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 3", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "scoped_variables": {}, 
+    "state_id": "BNLTCG", 
+    "transitions": {
+        "21": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "IKAANM", 
+            "to_outcome": 0, 
+            "to_state": "BNLTCG", 
+            "transition_id": 21
+        }, 
+        "22": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "IKAANM", 
+            "transition_id": 22
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_BNLTCG/hierarchy_4_IKAANM/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_BNLTCG/hierarchy_4_IKAANM/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": 5
+    }, 
+    "library_name": "hierarchy_4", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 4", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "IKAANM", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_USFTMR/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_USFTMR/core_data.json
@@ -1,0 +1,101 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "14": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 14, 
+            "from_key": 0, 
+            "from_state": "USFTMR", 
+            "to_key": 1, 
+            "to_state": "HLGSYC"
+        }, 
+        "15": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 15, 
+            "from_key": 0, 
+            "from_state": "HLGSYC", 
+            "to_key": 1, 
+            "to_state": "DBUDBF"
+        }, 
+        "16": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 16, 
+            "from_key": 0, 
+            "from_state": "DBUDBF", 
+            "to_key": 1, 
+            "to_state": "USFTMR"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 3", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "USFTMR", 
+    "transitions": {
+        "17": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "HLGSYC", 
+            "transition_id": 17
+        }, 
+        "18": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "HLGSYC", 
+            "to_outcome": null, 
+            "to_state": "DBUDBF", 
+            "transition_id": 18
+        }, 
+        "19": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "DBUDBF", 
+            "to_outcome": 0, 
+            "to_state": "USFTMR", 
+            "transition_id": 19
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_USFTMR/hierarchy_4_DBUDBF/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_USFTMR/hierarchy_4_DBUDBF/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_4", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 4", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "DBUDBF", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_USFTMR/hierarchy_4_HLGSYC/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/hierarchy_3_USFTMR/hierarchy_4_HLGSYC/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_4", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 4", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "HLGSYC", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_2/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:18:42", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/core_data.json
@@ -1,0 +1,85 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 7, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 0, 
+            "to_state": "RTYTLG"
+        }, 
+        "12": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 12, 
+            "from_key": 1, 
+            "from_state": "RTYTLG", 
+            "to_key": 0, 
+            "to_state": "MQRVHE"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 4", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "MQRVHE", 
+    "transitions": {
+        "10": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "RTYTLG", 
+            "transition_id": 10
+        }, 
+        "15": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "RTYTLG", 
+            "to_outcome": 0, 
+            "to_state": "MQRVHE", 
+            "transition_id": 15
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/core_data.json
@@ -1,0 +1,117 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 8, 
+            "from_key": 0, 
+            "from_state": "RTYTLG", 
+            "to_key": 1, 
+            "to_state": "KQZDCO"
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 9, 
+            "from_key": 0, 
+            "from_state": "KQZDCO", 
+            "to_key": 1, 
+            "to_state": "EERHBJ"
+        }, 
+        "10": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 10, 
+            "from_key": 0, 
+            "from_state": "EERHBJ", 
+            "to_key": 1, 
+            "to_state": "PSNSWC"
+        }, 
+        "11": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 11, 
+            "from_key": 0, 
+            "from_state": "PSNSWC", 
+            "to_key": 1, 
+            "to_state": "RTYTLG"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 5", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "RTYTLG", 
+    "transitions": {
+        "11": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "PSNSWC", 
+            "to_outcome": 0, 
+            "to_state": "RTYTLG", 
+            "transition_id": 11
+        }, 
+        "12": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "EERHBJ", 
+            "to_outcome": null, 
+            "to_state": "PSNSWC", 
+            "transition_id": 12
+        }, 
+        "13": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "KQZDCO", 
+            "to_outcome": null, 
+            "to_state": "EERHBJ", 
+            "transition_id": 13
+        }, 
+        "14": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "KQZDCO", 
+            "transition_id": 14
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/hierarchy_6_EERHBJ/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/hierarchy_6_EERHBJ/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_6", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 6", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "EERHBJ", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/hierarchy_6_KQZDCO/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/hierarchy_6_KQZDCO/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_6", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 6", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "KQZDCO", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/hierarchy_6_PSNSWC/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/hierarchy_5_RTYTLG/hierarchy_6_PSNSWC/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_6", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 6", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "PSNSWC", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_4/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:18:42", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/ExecutionState_1_HDCCAK/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/ExecutionState_1_HDCCAK/core_data.json
@@ -1,0 +1,38 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "name": "ExecutionState 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "HDCCAK"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/ExecutionState_1_HDCCAK/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/ExecutionState_1_HDCCAK/script.py
@@ -1,5 +1,3 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    outputs
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/ExecutionState_1_HDCCAK/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/ExecutionState_1_HDCCAK/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    outputs
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/core_data.json
@@ -1,0 +1,117 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 4, 
+            "from_key": 0, 
+            "from_state": "WNUIMB", 
+            "to_key": 0, 
+            "to_state": "HDCCAK"
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 5, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 1, 
+            "to_state": "WNUIMB"
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 6, 
+            "from_key": 0, 
+            "from_state": "IGBWJD", 
+            "to_key": 0, 
+            "to_state": "MQRVHE"
+        }, 
+        "10": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 10, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 1, 
+            "to_state": "IGBWJD"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 6", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "MQRVHE", 
+    "transitions": {
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "WNUIMB", 
+            "transition_id": 6
+        }, 
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "HDCCAK", 
+            "to_outcome": null, 
+            "to_state": "IGBWJD", 
+            "transition_id": 7
+        }, 
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "IGBWJD", 
+            "to_outcome": 0, 
+            "to_state": "MQRVHE", 
+            "transition_id": 8
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "WNUIMB", 
+            "to_outcome": null, 
+            "to_state": "HDCCAK", 
+            "transition_id": 9
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/hierarchy_7_IGBWJD/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/hierarchy_7_IGBWJD/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_7", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 7", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "IGBWJD", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/hierarchy_7_WNUIMB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/hierarchy_7_WNUIMB/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_7", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 7", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "WNUIMB", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_6/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:18:42", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/core_data.json
@@ -1,0 +1,141 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 1, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 1, 
+            "to_state": "XYZSJY"
+        }, 
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 2, 
+            "from_key": 0, 
+            "from_state": "XYZSJY", 
+            "to_key": 0, 
+            "to_state": "MQRVHE"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 3, 
+            "from_key": 0, 
+            "from_state": "EEIMTJ", 
+            "to_key": 0, 
+            "to_state": "MQRVHE"
+        }, 
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 7, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 1, 
+            "to_state": "NAZPJD"
+        }, 
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 8, 
+            "from_key": 0, 
+            "from_state": "NAZPJD", 
+            "to_key": 1, 
+            "to_state": "MFIJJW"
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 9, 
+            "from_key": 0, 
+            "from_state": "MFIJJW", 
+            "to_key": 1, 
+            "to_state": "EEIMTJ"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 7", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "MQRVHE", 
+    "transitions": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "XYZSJY", 
+            "transition_id": 1
+        }, 
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "XYZSJY", 
+            "to_outcome": null, 
+            "to_state": "NAZPJD", 
+            "transition_id": 2
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NAZPJD", 
+            "to_outcome": null, 
+            "to_state": "MFIJJW", 
+            "transition_id": 3
+        }, 
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "MFIJJW", 
+            "to_outcome": null, 
+            "to_state": "EEIMTJ", 
+            "transition_id": 4
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "EEIMTJ", 
+            "to_outcome": 0, 
+            "to_state": "MQRVHE", 
+            "transition_id": 5
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_EEIMTJ/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_EEIMTJ/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_8", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 8", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "EEIMTJ", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_MFIJJW/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_MFIJJW/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_8", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 8", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "MFIJJW", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_NAZPJD/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_NAZPJD/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_8", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 8", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "NAZPJD", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_XYZSJY/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/hierarchy_8_XYZSJY/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_8", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 8", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "XYZSJY", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_7/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:18:42", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/core_data.json
@@ -1,0 +1,133 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 4, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 1, 
+            "to_state": "QLZDVA"
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 5, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 1, 
+            "to_state": "NFNPIE"
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 6, 
+            "from_key": 0, 
+            "from_state": "QLZDVA", 
+            "to_key": 1, 
+            "to_state": "KGGSFI"
+        }, 
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 8, 
+            "from_key": 0, 
+            "from_state": "NFNPIE", 
+            "to_key": 1, 
+            "to_state": "HYDOGG"
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 9, 
+            "from_key": 0, 
+            "from_state": "HYDOGG", 
+            "to_key": 0, 
+            "to_state": "MQRVHE"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 8", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "MQRVHE", 
+    "transitions": {
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "QLZDVA", 
+            "transition_id": 8
+        }, 
+        "9": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "QLZDVA", 
+            "to_outcome": null, 
+            "to_state": "KGGSFI", 
+            "transition_id": 9
+        }, 
+        "10": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "KGGSFI", 
+            "to_outcome": null, 
+            "to_state": "NFNPIE", 
+            "transition_id": 10
+        }, 
+        "11": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NFNPIE", 
+            "to_outcome": null, 
+            "to_state": "HYDOGG", 
+            "transition_id": 11
+        }, 
+        "12": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "HYDOGG", 
+            "to_outcome": 0, 
+            "to_state": "MQRVHE", 
+            "transition_id": 12
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_HYDOGG/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_HYDOGG/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_9", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 9", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "HYDOGG", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_KGGSFI/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_KGGSFI/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_9", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 9", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "KGGSFI", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_NFNPIE/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_NFNPIE/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_9", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 9", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "NFNPIE", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_QLZDVA/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/hierarchy_9_QLZDVA/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": null
+    }, 
+    "library_name": "hierarchy_9", 
+    "library_path": "develop_test", 
+    "name": "hierarchy 9", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "0": null
+    }, 
+    "state_id": "QLZDVA", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "0": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_8/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:18:42", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/core_data.json
@@ -1,0 +1,133 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 1, 
+            "from_key": 1, 
+            "from_state": "NGINSR", 
+            "to_key": 0, 
+            "to_state": "YTDGPP"
+        }, 
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 2, 
+            "from_key": 1, 
+            "from_state": "NGINSR", 
+            "to_key": 0, 
+            "to_state": "QIKWYB"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 3, 
+            "from_key": 1, 
+            "from_state": "QIKWYB", 
+            "to_key": 0, 
+            "to_state": "IRZSZB"
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 5, 
+            "from_key": 1, 
+            "from_state": "MQRVHE", 
+            "to_key": 0, 
+            "to_state": "NGINSR"
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 6, 
+            "from_key": 1, 
+            "from_state": "IRZSZB", 
+            "to_key": 0, 
+            "to_state": "MQRVHE"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "input_1"
+        }
+    }, 
+    "name": "hierarchy 9", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "MQRVHE", 
+    "transitions": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "NGINSR", 
+            "to_outcome": null, 
+            "to_state": "QIKWYB", 
+            "transition_id": 1
+        }, 
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "QIKWYB", 
+            "to_outcome": null, 
+            "to_state": "YTDGPP", 
+            "transition_id": 4
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "YTDGPP", 
+            "to_outcome": null, 
+            "to_state": "IRZSZB", 
+            "transition_id": 5
+        }, 
+        "6": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "NGINSR", 
+            "transition_id": 6
+        }, 
+        "7": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "IRZSZB", 
+            "to_outcome": 0, 
+            "to_state": "MQRVHE", 
+            "transition_id": 7
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_1_NGINSR/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_1_NGINSR/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null
+    }, 
+    "library_name": "example_interface_1", 
+    "library_path": "develop_test", 
+    "name": "example interface 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "1": null
+    }, 
+    "state_id": "NGINSR", 
+    "use_runtime_value_input_data_ports": {
+        "0": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "1": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_1_YTDGPP/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_1_YTDGPP/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null
+    }, 
+    "library_name": "example_interface_1", 
+    "library_path": "develop_test", 
+    "name": "example interface 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "1": null
+    }, 
+    "state_id": "YTDGPP", 
+    "use_runtime_value_input_data_ports": {
+        "0": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "1": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_2_IRZSZB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_2_IRZSZB/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null
+    }, 
+    "library_name": "example_interface_2", 
+    "library_path": "develop_test", 
+    "name": "example interface 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "1": null
+    }, 
+    "state_id": "IRZSZB", 
+    "use_runtime_value_input_data_ports": {
+        "0": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "1": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_2_QIKWYB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/example_interface_2_QIKWYB/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null
+    }, 
+    "library_name": "example_interface_2", 
+    "library_path": "develop_test", 
+    "name": "example interface 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "1": null
+    }, 
+    "state_id": "QIKWYB", 
+    "use_runtime_value_input_data_ports": {
+        "0": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "1": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/hierarchy_9/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 15:18:42", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/core_data.json
@@ -1,0 +1,28 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "init ros2 node", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "DGBHYK"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/script.py
@@ -1,6 +1,4 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(0.4)
     gvm.set_variable("ros_initialized", True)
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/script.py
@@ -1,0 +1,6 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(0.4)
+    gvm.set_variable("ros_initialized", True)
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/init_ros2_node/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:54:20", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/configure_camera_UDZIUH/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/configure_camera_UDZIUH/core_data.json
@@ -1,0 +1,29 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {}, 
+    "library_name": "configure_camera", 
+    "library_path": "develop_test", 
+    "name": "configure camera", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {}, 
+    "state_id": "UDZIUH", 
+    "use_runtime_value_input_data_ports": {}, 
+    "use_runtime_value_output_data_ports": {}, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/core_data.json
@@ -1,0 +1,56 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {}, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "initialize camera", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "scoped_variables": {}, 
+    "state_id": "HCPIPT", 
+    "transitions": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "HVCVWB", 
+            "transition_id": 1
+        }, 
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "HVCVWB", 
+            "to_outcome": null, 
+            "to_state": "UDZIUH", 
+            "transition_id": 2
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "UDZIUH", 
+            "to_outcome": 0, 
+            "to_state": "HCPIPT", 
+            "transition_id": 3
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/prepare_camera_initialization_HVCVWB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/prepare_camera_initialization_HVCVWB/core_data.json
@@ -1,0 +1,28 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "prepare camera initialization", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "HVCVWB"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/prepare_camera_initialization_HVCVWB/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/prepare_camera_initialization_HVCVWB/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(2)
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/prepare_camera_initialization_HVCVWB/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/prepare_camera_initialization_HVCVWB/script.py
@@ -1,5 +1,3 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(2)
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_camera/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:49:18", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/configure_camera_CQMWTD/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/configure_camera_CQMWTD/core_data.json
@@ -1,0 +1,29 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {}, 
+    "library_name": "configure_world", 
+    "library_path": "develop_test", 
+    "name": "configure camera", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {}, 
+    "state_id": "CQMWTD", 
+    "use_runtime_value_input_data_ports": {}, 
+    "use_runtime_value_output_data_ports": {}, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/core_data.json
@@ -1,0 +1,56 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {}, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "initialize world", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "scoped_variables": {}, 
+    "state_id": "HCPIPT", 
+    "transitions": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "HVCVWB", 
+            "transition_id": 1
+        }, 
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "HVCVWB", 
+            "to_outcome": null, 
+            "to_state": "CQMWTD", 
+            "transition_id": 2
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "CQMWTD", 
+            "to_outcome": 0, 
+            "to_state": "HCPIPT", 
+            "transition_id": 3
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/prepare_camera_initialization_HVCVWB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/prepare_camera_initialization_HVCVWB/core_data.json
@@ -1,0 +1,28 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "prepare camera initialization", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "state_id": "HVCVWB"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/prepare_camera_initialization_HVCVWB/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/prepare_camera_initialization_HVCVWB/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(0.2)
+    return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/prepare_camera_initialization_HVCVWB/script.py
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/prepare_camera_initialization_HVCVWB/script.py
@@ -1,5 +1,3 @@
 
 def execute(self, inputs, outputs, gvm):
-    self.logger.info("Hello {}".format(self.name))
-    self.preemptive_wait(0.2)
     return "success"

--- a/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/develop_test_libraries/initialize_world/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:49:18", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/core_data.json
@@ -1,0 +1,81 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "22": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 22, 
+            "from_key": 2, 
+            "from_state": "QIZZOB", 
+            "to_key": 0, 
+            "to_state": "RYZGLE"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "Example demo state machine", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {}, 
+    "scoped_variables": {}, 
+    "state_id": "QBYTMD", 
+    "transitions": {
+        "8": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "IQRKRY", 
+            "transition_id": 8
+        }, 
+        "13": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "IQRKRY", 
+            "to_outcome": null, 
+            "to_state": "IPGWAT", 
+            "transition_id": 13
+        }, 
+        "28": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "IPGWAT", 
+            "to_outcome": null, 
+            "to_state": "QIZZOB", 
+            "transition_id": 28
+        }, 
+        "30": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "QIZZOB", 
+            "to_outcome": null, 
+            "to_state": "RYZGLE", 
+            "transition_id": 30
+        }, 
+        "31": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "RYZGLE", 
+            "to_outcome": 0, 
+            "to_state": "QBYTMD", 
+            "transition_id": 31
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/example_set_some_data_IPGWAT/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/example_set_some_data_IPGWAT/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "2": 14
+    }, 
+    "library_name": "example_set_some_data", 
+    "library_path": "develop_test/example_state_machines", 
+    "name": "example set some data", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "3": null
+    }, 
+    "state_id": "IPGWAT", 
+    "use_runtime_value_input_data_ports": {
+        "2": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "3": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/initialize_robot_and_world_IQRKRY/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/initialize_robot_and_world_IQRKRY/core_data.json
@@ -1,0 +1,29 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {}, 
+    "library_name": "example_initialize", 
+    "library_path": "develop_test/example_state_machines", 
+    "name": "initialize robot and world", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {}, 
+    "state_id": "IQRKRY", 
+    "use_runtime_value_input_data_ports": {}, 
+    "use_runtime_value_output_data_ports": {}, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/statemachine.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2025-09-18 14:46:40", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.2.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/task_1_QIZZOB/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/task_1_QIZZOB/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "1": 78
+    }, 
+    "library_name": "task_1", 
+    "library_path": "develop_test/example_state_machines", 
+    "name": "task 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "2": null
+    }, 
+    "state_id": "QIZZOB", 
+    "use_runtime_value_input_data_ports": {
+        "1": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "2": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/task_2_RYZGLE/core_data.json
+++ b/tests/assets/unit_test_state_machines/start_from_here_test/example_demo_state_machine/task_2_RYZGLE/core_data.json
@@ -1,0 +1,37 @@
+{
+    "__jsonqualname__": "rafcon.core.states.library_state.LibraryState", 
+    "input_data_port_runtime_values": {
+        "0": null
+    }, 
+    "library_name": "task_2", 
+    "library_path": "develop_test/example_state_machines", 
+    "name": "task 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_port_runtime_values": {
+        "1": null
+    }, 
+    "state_id": "RYZGLE", 
+    "use_runtime_value_input_data_ports": {
+        "0": true
+    }, 
+    "use_runtime_value_output_data_ports": {
+        "1": true
+    }, 
+    "version": "0.1"
+}

--- a/tests/core/test_start_from_here.py
+++ b/tests/core/test_start_from_here.py
@@ -1,0 +1,144 @@
+import os
+
+import rafcon.core.singleton
+from rafcon.core.execution.execution_history_items import CallItem
+from tests import utils as testing_utils
+
+SM_PATH = os.path.join("unit_test_state_machines", "start_from_here_test", "example_demo_state_machine")
+LIB_PATH = os.path.join(testing_utils.TEST_STATE_MACHINES_PATH, "start_from_here_test", "develop_test_libraries")
+ROOT = "QBYTMD"
+
+# top-level tasks
+TASK_1 = ROOT + "/QIZZOB"
+TASK_2 = ROOT + "/RYZGLE"
+
+# inside task_1 (LZLXFW is the HierarchyState wrapping the library)
+BARRIER_CONCURRENCY    = ROOT + "/QIZZOB/LZLXFW/KEQYNU"   # all branches must finish before moving on
+PREEMPTIVE_CONCURRENCY = ROOT + "/QIZZOB/LZLXFW/AESIQF"   # fastest branch cancels the rest
+
+# inside task_2 (EAWGCM is the HierarchyState wrapping the library)
+HIERARCHY2_IN_TASK2 = ROOT + "/RYZGLE/EAWGCM/SFSEDE"              # first hierarchy_2 in task_2
+NESTED_LIBRARY      = ROOT + "/RYZGLE/EAWGCM/SFSEDE/MQRVHE/BNLTCG/IKAANM"  # hierarchy_4, 3 libs deep
+
+
+def _replay_from(sm, target_path):
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    run_1 = sm.execution_histories[0]
+    call_item = next(
+        (item for item in run_1
+         if isinstance(item, CallItem) and item.call_type_str == 'EXECUTE' and item.path == target_path),
+        None
+    )
+    assert call_item is not None, f"No EXECUTE CallItem found at '{target_path}'"
+    engine.replay_from_history(call_item, sm)
+    engine.start(sm.state_machine_id)
+    engine.join()
+    engine.stop()
+
+
+def _output(sm):
+    return sm.root_state.states["RYZGLE"].output_data["output_1"]
+
+
+def test_full_run(caplog):
+    # baseline: full run from the beginning
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    try:
+        assert len(sm.execution_histories) == 1
+        assert _output(sm) == 295
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+def test_replay_from_task1(caplog):
+    # start from task_1 - verify both task_1 and task_2 produce correct outputs
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    _replay_from(sm, TASK_1)
+    try:
+        assert sm.root_state.states["QIZZOB"].output_data["output_1"] == 79
+        assert _output(sm) == 295
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+def test_replay_from_task2(caplog):
+    # task_1 is skipped, its output is restored from history, task_2 re-runs
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    _replay_from(sm, TASK_2)
+    try:
+        assert len(sm.execution_histories) == 2
+        assert _output(sm) == 295
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+def test_replay_from_barrier_concurrency(caplog):
+    # start from inside task_1 at the barrier concurrency 
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    _replay_from(sm, BARRIER_CONCURRENCY)
+    try:
+        assert _output(sm) == 295
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+def test_replay_from_preemptive_concurrency(caplog):
+    # start from the preemptive concurrency inside task_1
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    _replay_from(sm, PREEMPTIVE_CONCURRENCY)
+    try:
+        assert _output(sm) == 295
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+def test_replay_from_deep_hierarchy(caplog):
+    # start from hierarchy_2 inside task_2, skipping task_1 entirely
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    _replay_from(sm, HIERARCHY2_IN_TASK2)
+    try:
+        assert _output(sm) == 295
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+def test_replay_from_nested_library(caplog):
+    # IKAANM is hierarchy_4 - a library state three levels deep inside task_2
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    _replay_from(sm, NESTED_LIBRARY)
+    try:
+        assert _output(sm) == 295
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+def test_multiple_replays_from_run1(caplog):
+    # run 1 stays intact - each replay creates a new run, all sourced from run 1
+    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
+    engine = rafcon.core.singleton.state_machine_execution_engine
+    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
+    _replay_from(sm, TASK_2)
+    _replay_from(sm, TASK_1)
+    try:
+        assert _output(sm) == 295
+        assert len(sm.execution_histories) == 3
+    finally:
+        testing_utils.shutdown_environment_only_core(caplog=caplog)
+
+
+if __name__ == '__main__':
+    test_full_run(None)

--- a/tests/core/test_start_from_here.py
+++ b/tests/core/test_start_from_here.py
@@ -17,7 +17,6 @@ BARRIER_CONCURRENCY    = ROOT + "/QIZZOB/LZLXFW/KEQYNU"   # all branches must fi
 PREEMPTIVE_CONCURRENCY = ROOT + "/QIZZOB/LZLXFW/AESIQF"   # fastest branch cancels the rest
 
 # inside task_2 (EAWGCM is the HierarchyState wrapping the library)
-HIERARCHY2_IN_TASK2 = ROOT + "/RYZGLE/EAWGCM/SFSEDE"              # first hierarchy_2 in task_2
 NESTED_LIBRARY      = ROOT + "/RYZGLE/EAWGCM/SFSEDE/MQRVHE/BNLTCG/IKAANM"  # hierarchy_4, 3 libs deep
 
 
@@ -40,105 +39,45 @@ def _output(sm):
     return sm.root_state.states["RYZGLE"].output_data["output_1"]
 
 
-def test_full_run(caplog):
+def test_output_from_multiple_start_points(caplog):
     # baseline: full run from the beginning
     testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
     engine = rafcon.core.singleton.state_machine_execution_engine
     sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
     try:
+        # test output correct on full run
         assert len(sm.execution_histories) == 1
         assert _output(sm) == 295
-    finally:
-        testing_utils.shutdown_environment_only_core(caplog=caplog)
 
-
-def test_replay_from_task1(caplog):
-    # start from task_1 - verify both task_1 and task_2 produce correct outputs
-    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
-    engine = rafcon.core.singleton.state_machine_execution_engine
-    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
-    _replay_from(sm, TASK_1)
-    try:
+        # test output correct from task 1
+        _replay_from(sm, TASK_1)
         assert sm.root_state.states["QIZZOB"].output_data["output_1"] == 79
         assert _output(sm) == 295
-    finally:
-        testing_utils.shutdown_environment_only_core(caplog=caplog)
 
-
-def test_replay_from_task2(caplog):
-    # task_1 is skipped, its output is restored from history, task_2 re-runs
-    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
-    engine = rafcon.core.singleton.state_machine_execution_engine
-    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
-    _replay_from(sm, TASK_2)
-    try:
-        assert len(sm.execution_histories) == 2
+        # test output correct from task 2
+        _replay_from(sm, TASK_2)
         assert _output(sm) == 295
-    finally:
-        testing_utils.shutdown_environment_only_core(caplog=caplog)
 
-
-def test_replay_from_barrier_concurrency(caplog):
-    # start from inside task_1 at the barrier concurrency 
-    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
-    engine = rafcon.core.singleton.state_machine_execution_engine
-    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
-    _replay_from(sm, BARRIER_CONCURRENCY)
-    try:
+        # test output correct from barrier concurrency
+        _replay_from(sm, BARRIER_CONCURRENCY)
         assert _output(sm) == 295
-    finally:
-        testing_utils.shutdown_environment_only_core(caplog=caplog)
 
-
-def test_replay_from_preemptive_concurrency(caplog):
-    # start from the preemptive concurrency inside task_1
-    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
-    engine = rafcon.core.singleton.state_machine_execution_engine
-    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
-    _replay_from(sm, PREEMPTIVE_CONCURRENCY)
-    try:
+        # test output correct from preemptive concurrency
+        _replay_from(sm, PREEMPTIVE_CONCURRENCY)
         assert _output(sm) == 295
-    finally:
-        testing_utils.shutdown_environment_only_core(caplog=caplog)
 
-
-def test_replay_from_deep_hierarchy(caplog):
-    # start from hierarchy_2 inside task_2, skipping task_1 entirely
-    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
-    engine = rafcon.core.singleton.state_machine_execution_engine
-    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
-    _replay_from(sm, HIERARCHY2_IN_TASK2)
-    try:
+        # test output correct from lower nested hierarchy
+        _replay_from(sm, NESTED_LIBRARY)
         assert _output(sm) == 295
-    finally:
-        testing_utils.shutdown_environment_only_core(caplog=caplog)
 
-
-def test_replay_from_nested_library(caplog):
-    # IKAANM is hierarchy_4 - a library state three levels deep inside task_2
-    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
-    engine = rafcon.core.singleton.state_machine_execution_engine
-    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
-    _replay_from(sm, NESTED_LIBRARY)
-    try:
+        # test output correct after multiple replays
+        _replay_from(sm, TASK_2)
+        _replay_from(sm, TASK_1)
         assert _output(sm) == 295
-    finally:
-        testing_utils.shutdown_environment_only_core(caplog=caplog)
-
-
-def test_multiple_replays_from_run1(caplog):
-    # run 1 stays intact - each replay creates a new run, all sourced from run 1
-    testing_utils.initialize_environment_core(libraries={"develop_test": LIB_PATH})
-    engine = rafcon.core.singleton.state_machine_execution_engine
-    sm = engine.execute_state_machine_from_path(path=testing_utils.get_test_sm_path(SM_PATH))
-    _replay_from(sm, TASK_2)
-    _replay_from(sm, TASK_1)
-    try:
-        assert _output(sm) == 295
-        assert len(sm.execution_histories) == 3
+        assert len(sm.execution_histories) == 8
     finally:
         testing_utils.shutdown_environment_only_core(caplog=caplog)
 
 
 if __name__ == '__main__':
-    test_full_run(None)
+    test_output_from_multiple_start_points(None)


### PR DESCRIPTION
## Goal
  When debugging state machines with long execution paths or complex parallel branches, developers often need to test specific states repeatedly. Currently, they must restart the entire state machine
  each time. This feature allows starting execution from any historical execution point, saving significant debugging time.

  ## Changes
  - Add `replay_from_history()` method to ExecutionEngine for starting execution from history items
  - Build runtime context map from execution history to restore scoped_data at target timestamp
  - Add context menu "Start From Here" option in execution history tree view
  - Restore scoped data for container states during replay to maintain correct runtime state
  - Handle parallel branch states by collecting data from all concurrent branches at replay point

  ## How It Works
  When a user right-clicks on a CallItem in the execution history and selects "Start From Here", the system:
  1. Reconstructs the runtime state (scoped_data or scoped_variables) at that historical point by walking backwards through execution history from history_items, IN_MEMORY_EXECUTION must be enabled in config, to retrieve historical data from python object.
  2. Handles parallel execution branches by collecting state from all concurrent branches at the target timestamp
  3. Sets the execution start path and begins step-mode execution from that point

  ## Testing
  1. Run a state machine with nested hierarchy states
  2. After completion, open the execution history view
  3. Right-click on any CallItem and select "Start From Here"
  4. Verify execution begins from that point with correct scoped_data/variables and end results are as expected