### PR TITLE
Feat/autoscroll

### DIFF
--- a/source/rafcon/gui/controllers/graphical_editor_gaphas.py
+++ b/source/rafcon/gui/controllers/graphical_editor_gaphas.py
@@ -201,8 +201,6 @@ class GraphicalEditorController(ExtendedController):
         :param y: Integer: y-position of mouse
         :param time:
         """
-        #this function is first for drag-and-drop functionality for library states, then on_drag_data_received
-        logger.debug(f"[GraphicalEditorcontroller]---------> on_drag_motion executed!<----------")
         hovered_item = ItemFinder(self.view.editor).get_item_at_point((x, y))
         if isinstance(hovered_item, NameView):
             hovered_item = hovered_item.parent

--- a/source/rafcon/gui/controllers/graphical_editor_gaphas.py
+++ b/source/rafcon/gui/controllers/graphical_editor_gaphas.py
@@ -175,6 +175,8 @@ class GraphicalEditorController(ExtendedController):
         :param info:
         :param time:
         """
+        ### Hier wird das object bei drag and drop mit der maus bewegt/angeglichen
+        logger.info(f"[GraphicalEditorController]------> on_drag_data_received executed!<------")
         state_id_insert = data.get_text()
         parent_m = self.model.selection.get_selected_state()
         if not isinstance(parent_m, ContainerStateModel):
@@ -199,6 +201,8 @@ class GraphicalEditorController(ExtendedController):
         :param y: Integer: y-position of mouse
         :param time:
         """
+        #this function is first for drag-and-drop functionality for library states, then on_drag_data_received
+        logger.debug(f"[GraphicalEditorcontroller]---------> on_drag_motion executed!<----------")
         hovered_item = ItemFinder(self.view.editor).get_item_at_point((x, y))
         if isinstance(hovered_item, NameView):
             hovered_item = hovered_item.parent
@@ -288,6 +292,7 @@ class GraphicalEditorController(ExtendedController):
 
         :param StateView | ConnectionView | PortView item: The item to be moved into the viewport
         """
+        logger.debug("[GraphicalEditorController]:-------> item is moved into viewport <--------")
         if not item:
             return
         HORIZONTAL = 0
@@ -394,7 +399,7 @@ class GraphicalEditorController(ExtendedController):
 
     @ExtendedController.observe("state_machine", after=True)
     def state_machine_change_after(self, model, prop_name, info):
-        """Called on any change within th state machine
+        """Called on any change within the state machine
 
         This method is called, when any state, transition, data flow, etc. within the state machine changes. This
         then typically requires a redraw of the graphical editor, to display these changes immediately.

--- a/source/rafcon/gui/controllers/graphical_editor_gaphas.py
+++ b/source/rafcon/gui/controllers/graphical_editor_gaphas.py
@@ -175,8 +175,7 @@ class GraphicalEditorController(ExtendedController):
         :param info:
         :param time:
         """
-        ### Hier wird das object bei drag and drop mit der maus bewegt/angeglichen
-        logger.info(f"[GraphicalEditorController]------> on_drag_data_received executed!<------")
+
         state_id_insert = data.get_text()
         parent_m = self.model.selection.get_selected_state()
         if not isinstance(parent_m, ContainerStateModel):
@@ -290,7 +289,7 @@ class GraphicalEditorController(ExtendedController):
 
         :param StateView | ConnectionView | PortView item: The item to be moved into the viewport
         """
-        logger.debug("[GraphicalEditorController]:-------> item is moved into viewport <--------")
+        
         if not item:
             return
         HORIZONTAL = 0

--- a/source/rafcon/gui/mygaphas/canvas.py
+++ b/source/rafcon/gui/mygaphas/canvas.py
@@ -154,7 +154,7 @@ class MyCanvas(gaphas.canvas.Canvas):
 class ItemProjection(object):
     """Project a point of item A into the coordinate system of item B.
 
-    The class os based on the implementation of gaphas.canvas.CanvasProjection.
+    The class is based on the implementation of gaphas.canvas.CanvasProjection.
     """
 
     def __init__(self, point, item_point, item_target):

--- a/source/rafcon/gui/mygaphas/guide.py
+++ b/source/rafcon/gui/mygaphas/guide.py
@@ -90,9 +90,6 @@ class GuidedStateInMotion(GuidedStateMixin, GuidedItemInMotion):
     def move(self, pos):
         if not self.item.moving:
             return
-        #----------------------------------------------------
-        logger.debug(f"[GuidedstateInMotion] -> current position of move command: {pos}")
-        #----------------------------------------------------
         super(GuidedStateInMotion, self).move(pos)
         parent_item = self.item.parent
         if parent_item:    ## e.g. parent_item=root state if I want to move HierarchyState1 inside root stae

--- a/source/rafcon/gui/mygaphas/guide.py
+++ b/source/rafcon/gui/mygaphas/guide.py
@@ -91,7 +91,7 @@ class GuidedStateInMotion(GuidedStateMixin, GuidedItemInMotion):
         if not self.item.moving:
             return
         #----------------------------------------------------
-        logger.debugs(f"[GuidedstateInMotion] -> current position of move command: {pos}")
+        logger.debug(f"[GuidedstateInMotion] -> current position of move command: {pos}")
         #----------------------------------------------------
         super(GuidedStateInMotion, self).move(pos)
         parent_item = self.item.parent

--- a/source/rafcon/gui/mygaphas/guide.py
+++ b/source/rafcon/gui/mygaphas/guide.py
@@ -17,6 +17,9 @@ from gaphas.aspect import InMotion, HandleInMotion
 from gaphas.guide import GuidedItemInMotion, GuidedItemHandleInMotion, Guide, GuideMixin
 
 from rafcon.gui.mygaphas.items.state import StateView, NameView
+from rafcon.utils import log
+
+logger = log.get_logger(__name__)
 
 
 class GuidedStateMixin(GuideMixin):
@@ -78,7 +81,6 @@ class GuidedStateMixin(GuideMixin):
 
 @InMotion.when_type(StateView)
 class GuidedStateInMotion(GuidedStateMixin, GuidedItemInMotion):
-
     def start_move(self, pos):
         if self.item and self.item.model and self.item.model.state.is_root_state:
             return
@@ -88,9 +90,12 @@ class GuidedStateInMotion(GuidedStateMixin, GuidedItemInMotion):
     def move(self, pos):
         if not self.item.moving:
             return
+        #----------------------------------------------------
+        logger.debugs(f"[GuidedstateInMotion] -> current position of move command: {pos}")
+        #----------------------------------------------------
         super(GuidedStateInMotion, self).move(pos)
         parent_item = self.item.parent
-        if parent_item:
+        if parent_item:    ## e.g. parent_item=root state if I want to move HierarchyState1 inside root stae
             constraint = parent_item.keep_rect_constraints[self.item]
             self.view.canvas.solver.request_resolve_constraint(constraint)
 

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -132,6 +132,7 @@ class MoveItemTool(gaphas.tool.ItemTool):
             for item in selected_items:
                 if not isinstance(item, Item):
                     continue
+                logger.debug("[MoveItemTool -> movable_items()] -> InMotion object is created for moving state machine in movable-items function")
                 yield InMotion(item, view)
 
     def on_button_press(self, event):
@@ -186,6 +187,8 @@ class MoveItemTool(gaphas.tool.ItemTool):
             inmotion.move((event.x, event.y))
             rel_pos = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
                                                         inmotion.item.handles()[NW])
+            logger.debug(f"[MoveItemTool -> on_button_release()] -> Relative pose when button released: {rel_pos}")
+            logger.debug(f"[MoveItemTool -> on_button_release()] -> Event pose when button released: x:{event.x}, y:{event.y} ")
             if isinstance(inmotion.item, StateView):
                 state_v = inmotion.item
                 state_m = state_v.model
@@ -449,6 +452,9 @@ class MultiSelectionTool(gaphas.tool.RubberbandTool):
     def on_motion_notify(self, event):
         if event.get_state()[1] & Gdk.EventMask.BUTTON_PRESS_MASK and event.get_state()[1] & \
                 constants.RUBBERBAND_MODIFIER:
+            
+            logger.debug(f"[MultiSelectionTool] --------> MultiSelectionTool active <------")
+
             view = self.view
             self.queue_draw(view)
             self.x1, self.y1 = event.x, event.y
@@ -521,6 +527,8 @@ class MoveHandleTool(gaphas.tool.HandleTool):
         item = self.grabbed_item
         resize_recursive = isinstance(item, StateView) and self.grabbed_handle in item.corner_handles and \
                            event.get_state()[1] & constants.RECURSIVE_RESIZE_MODIFIER
+        
+        logger.debug(f"[MoveHanldeTool]----->MoveHanldeTool active<-----")
 
         if resize_recursive:
             old_size = (item.width, item.height)
@@ -710,6 +718,8 @@ class ConnectionCreationTool(ConnectionTool):
         if not self._parent_state_v or not event.get_state()[1] & Gdk.EventMask.BUTTON_PRESS_MASK:
             return False
 
+        logger.debug(f"[ConnectionCreationTool]---->ConnectionCreationTool active<----")
+
         if not self._connection_v:
             # Create new temporary connection, with origin at the start port and target at the cursor
             self._create_temporary_connection()
@@ -795,6 +805,8 @@ class ConnectionModificationTool(ConnectionTool):
             self._disconnect_temporarily(self._start_port_v, target=modify_target)
             self.grab_handle(self._connection_v, self._end_handle)
             self._set_motion_handle(event)
+
+        logger.info(f"[ConnectionModificationTool] -------> ConnectionModificationTool active <-----")
 
         last_sink = self._current_sink
         self._current_sink = self.motion_handle.move((event.x, event.y))

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -65,7 +65,7 @@ class ToolChain(gaphas.tool.ToolChain):
 
 
 class AutoscrollMixin:
-    """ mixin class to add autoscroll to agaphas tool.
+    """ mixin class to add autoscroll to a gaphas tool.
     When an item or handle is dragged against the border of the graphical editor,
     the view is scrolled in that direction. The dragged item follows the curser.
 
@@ -73,7 +73,7 @@ class AutoscrollMixin:
     relies on the following attributes provided by the base classes.
         * ``self.view``             - the GtkView object on which the tool operates on
         * ``self._movable_items``   - InMotion objects, which are set by the ItemTool
-        * ``self.motion_handle``    - HanldeInMotion object. which is set by the HandleTool
+        * ``self.motion_handle``    - HandleInMotion object. which is set by the HandleTool
     Call ``self.__init_mixin__()`` in the tool`s ``__init__`` and
     ``self.handle_autoscroll(event.x, event.y)`` in the ``on_motion_notify`` event class
     of the gaphas tool
@@ -930,8 +930,6 @@ class ConnectionModificationTool(ConnectionTool):
             self._disconnect_temporarily(self._start_port_v, target=modify_target)
             self.grab_handle(self._connection_v, self._end_handle)
             self._set_motion_handle(event)
-
-        logger.info(f"[ConnectionModificationTool] -------> ConnectionModificationTool active <-----")
 
         last_sink = self._current_sink
         self._current_sink = self.motion_handle.move((event.x, event.y))

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -129,8 +129,17 @@ class AutoscrollMixin:
                 
                 for inmotion in self._movable_items:
                     
-                for inmotion in self._movable_items:
-                    if inmotion.item.parent.border_width in rel_pos:
+                for idx, inmotion in enumerate(self._movable_items):
+
+                    rel_pos = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
+                                                        inmotion.item.handles()[NW])
+                    # parent state boarders
+                    parent_border_left = parent_border_top = inmotion.item.parent.border_width
+                    parent_border_right = inmotion.item.parent.width - (inmotion.item.width + inmotion.item.parent.border_width)
+                    parent_border_bottom = inmotion.item.parent.height - (inmotion.item.height + inmotion.item.parent.border_width)
+                    
+                    if parent_border_left <= rel_pos[0] or parent_border_top <= rel_pos[1] or \
+                    parent_border_right >= rel_pos[0] or parent_border_bottom >= rel_pos[1]:
                         self._stop_autoscroll()
                         return
 
@@ -140,12 +149,6 @@ class AutoscrollMixin:
                     logger.debug(f"[_on_autoscroll()] -> new item pos: {offset_x, offset_y}")
                     logger.debug(f"[_on_autoscroll()] -> counter: {self._counter}")
 
-                    #self._last_event_pos = (x_, y_)  # -> somehow triggers weird jumping behavior
-                    '''
-                    Wenn ich rausspringe aus dem padding Bereich, wird iregendeine andere Pose übertragen, 
-                    an die das Item dann final geheftet wird. es soll aber am Mauszeiger bleiben
-                    --> Wie wird das beim ConnectionTool gemacht?
-                    '''
             elif getattr(self, 'motion_handle', None):
                 h_adj = self.view.get_hadjustment()
                 v_adj = self.view.get_vadjustment()
@@ -313,7 +316,7 @@ class MoveItemTool(gaphas.tool.ItemTool, AutoscrollMixin):
             inmotion.move((event.x, event.y))
             rel_pos = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
                                                         inmotion.item.handles()[NW])
-            logger.debug(f"[MoveItemTool -> on_button_release()] -> Relative pose when button released: {rel_pos}")
+            logger.debug(f"[MoveItemTool -> on_button_release()] -> Relative pose to parent when button released: {rel_pos}")
             logger.debug(f"[MoveItemTool -> on_button_release()] -> Event pose when button released: x:{event.x}, y:{event.y} ")
             if isinstance(inmotion.item, StateView):
                 state_v = inmotion.item

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -14,7 +14,7 @@
 # Rico Belder <rico.belder@dlr.de>
 # Sebastian Brunner <sebastian.brunner@dlr.de>
 
-from gi.repository import Gdk
+from gi.repository import Gdk, GObject
 from gaphas.aspect import HandleFinder, InMotion
 from gaphas.item import NW, Item
 import gaphas.tool
@@ -62,6 +62,115 @@ class ToolChain(gaphas.tool.ToolChain):
         if tool is None:
             return
         super(ToolChain, self).ungrab(tool)
+
+
+class AutoscrollMixin:
+    """
+    Helper class for all tools using autoscrolling.
+    """
+    def __init_mixin__(self) -> None:
+        self._scroll_timeout_id = 0
+        self._last_event_pos = (0, 0)
+        self._margin = 30
+        self._speed = 15
+        self._counter = 0
+
+    def _is_dragging(self) -> bool:
+        movable = getattr(self, '_movable_items', None)
+        handle = getattr(self, 'motion_handle', None)
+
+        if movable:
+            logger.debug(f"[_is_dragging()]: State is moved")
+        elif handle:
+            logger.debug(f"[_is_dragging()]: Handler is moved")
+            
+        return bool(movable) or bool(handle)
+
+    def _should_autoscroll(self, x, y) -> list:
+        # wird ständig aufgerufen -> overshoot (nur bei selected object)
+        width = self.view.get_allocated_width()
+        height = self.view.get_allocated_height()  
+
+        left_bound_hit = x < self._margin
+        rigth_bound_hit = x > width - self._margin
+        top_bound_hit = y < self._margin
+        bottom_bound_hit = y > height - self._margin
+
+        if left_bound_hit or rigth_bound_hit or top_bound_hit or bottom_bound_hit:
+            logger.debug("[_should autoscroll] -> active")
+        
+        return rigth_bound_hit, left_bound_hit, bottom_bound_hit, top_bound_hit
+
+    def _on_autoscroll(self) -> bool:
+
+        if not self._is_dragging():
+            self._stop_autoscroll()
+            return False
+        
+        x, y = self._last_event_pos # -> coordinates in editor world space
+        scroll = self._should_autoscroll(self._last_event_pos[0], self._last_event_pos[1])
+
+        dx = (scroll[0]-scroll[1]) * self._speed
+        dy = (scroll[2]-scroll[3]) * self._speed
+
+        x_= x + (self._counter * dx)
+        y_ = y + (self._counter * dy)
+
+        logger.debug(f"[_on_autoscroll()] -> last event pos: {x}, {y}")
+        logger.debug(f"[_on_autoscroll()] -> new scroll pos: {x_, y_}")
+
+        if dx or dy:
+            movable_items = getattr(self, '_movable_items', None)
+            if movable_items: 
+                h_adj = self.view.get_hadjustment()
+                v_adj = self.view.get_vadjustment()
+                h_adj.set_value(h_adj.get_value() + dx)
+                v_adj.set_value(v_adj.get_value() + dy)
+                
+                for inmotion in self._movable_items:
+                    
+                    inmotion.move((x_, y_))
+                    self._counter += 1
+
+                    logger.debug(f"[_on_autoscroll()] -> new item pos: {x_, y_}")
+                    logger.debug(f"[_on_autoscroll()] -> counter: {self._counter}")
+
+                    #self._last_event_pos = (x_, y_)  # -> somehow triggers weird jumping behavior
+                    '''
+                    Wenn ich rausspringe aus dem padding Bereich, wird iregendeine andere Pose übertragen, 
+                    an die das Item dann final geheftet wird. es soll aber am Mauszeiger bleiben
+                    --> Wie wird das beim ConnectionTool gemacht?
+                    '''
+            
+
+            motion_handle = getattr(self, 'motion_handle', None)
+            if motion_handle:
+                h_adj = self.view.get_hadjustment()
+                v_adj = self.view.get_vadjustment()
+                h_adj.set_value(h_adj.get_value() + dx)
+                v_adj.set_value(v_adj.get_value() + dy)
+
+                motion_handle.move((x_, y_))
+                self._counter += 1
+            
+            '''
+            LÄUFT!!: ---> JETZT NOCH SCHÖNER MACHEN!
+            '''
+        return True
+
+    def _stop_autoscroll(self):
+        if self._scroll_timeout_id:
+            GObject.source_remove(self._scroll_timeout_id)
+            self._scroll_timeout_id = 0
+            self._counter = 0  
+
+    def handle_autoscroll(self, x, y) -> None:
+        self._last_event_pos = (x, y) # gets just updated if on_motion_notify is called
+        if self._is_dragging() and any(self._should_autoscroll(x, y)):
+            if not self._scroll_timeout_id:
+                self._scroll_timeout_id = GObject.timeout_add(50, self._on_autoscroll)
+        else:
+            self._stop_autoscroll()
 
 
 class PanTool(gaphas.tool.PanTool):

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -308,6 +308,7 @@ class MoveItemTool(gaphas.tool.ItemTool, AutoscrollMixin):
 
         :param event: The button event
         """
+        self._stop_autoscroll()
         affected_models = {}
 
         for inmotion in self._movable_items:
@@ -668,6 +669,7 @@ class MoveHandleTool(gaphas.tool.HandleTool, AutoscrollMixin):
         return True
 
     def on_button_release(self, event):
+        self._stop_autoscroll()
         if self.grabbed_item:
             item = self.grabbed_item
 
@@ -707,6 +709,7 @@ class ConnectionTool(gaphas.tool.ConnectHandleTool, AutoscrollMixin):
         self._current_sink = None
 
     def on_button_release(self, event):
+        self._stop_autoscroll()
         self._is_transition = False
         self._connection_v = None
         self._start_port_v = None

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -105,16 +105,16 @@ class AutoscrollMixin:
 
         if not self._is_dragging():
             self._stop_autoscroll()
-            return
+            return False
         
-        x, y = self._last_event_pos # -> coordinates in editor world space
+        x, y = self._last_event_pos
         scroll = self._should_autoscroll(self._last_event_pos[0], self._last_event_pos[1])
 
         dx = (scroll[0]-scroll[1]) * self._speed
         dy = (scroll[2]-scroll[3]) * self._speed
 
-        offset_x= x + (self._counter * dx) 
-        offset_y = y + (self._counter * dy)
+        offset_x= x + dx
+        offset_y = y + dy
 
         logger.debug(f"[_on_autoscroll()] -> last event pos: {x}, {y}")
         logger.debug(f"[_on_autoscroll()] -> new scroll pos: {offset_x, offset_y}")
@@ -129,11 +129,7 @@ class AutoscrollMixin:
                 
                 for inmotion in self._movable_items:
                     
-                for idx, inmotion in enumerate(self._movable_items):
-
-                    rel_pos = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
-                                                        inmotion.item.handles()[NW])
-                    # parent state boarders
+                    # parent state boarders to stop autoscrolling when boarders are hit
                     parent_border_left = parent_border_top = inmotion.item.parent.border_width
                     parent_border_right = inmotion.item.parent.width - (inmotion.item.width + inmotion.item.parent.border_width)
                     parent_border_bottom = inmotion.item.parent.height - (inmotion.item.height + inmotion.item.parent.border_width)
@@ -144,13 +140,14 @@ class AutoscrollMixin:
                     if rel_x in (parent_border_left, parent_border_right) or \
                        rel_y in (parent_border_top, parent_border_bottom):
                         self._stop_autoscroll()
-                        return
-
-                    inmotion.move((offset_x, offset_y))
-                    self._counter += 1
+                        return True
+                    
+                    # *2 to compensate for the shifted view coordinates
+                    inmotion.move((x+2*dx, y+2*dy))
+                    inmotion.last_x = offset_x
+                    inmotion.last_y = offset_y
 
                     logger.debug(f"[_on_autoscroll()] -> new item pos: {offset_x, offset_y}")
-                    logger.debug(f"[_on_autoscroll()] -> counter: {self._counter}")
 
             elif getattr(self, 'motion_handle', None):
                 h_adj = self.view.get_hadjustment()
@@ -161,9 +158,6 @@ class AutoscrollMixin:
                 self.motion_handle.move((offset_x, offset_y))
                 self._counter += 1
             
-            '''
-            LÄUFT!!: ---> JETZT NOCH SCHÖNER MACHEN!
-            '''
         return True
 
     def _stop_autoscroll(self):

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -65,39 +65,58 @@ class ToolChain(gaphas.tool.ToolChain):
 
 
 class AutoscrollMixin:
+    """ mixin class to add autoscroll to agaphas tool.
+    When an item or handle is dragged against the border of the graphical editor,
+    the view is scrolled in that direction. The dragged item follows the curser.
+
+    This mixin class expects to be combined with a ``gaphas`` tool and
+    relies on the following attributes provided by the base classes.
+        * ``self.view``             - the GtkView object on which the tool operates on
+        * ``self._movable_items``   - InMotion objects, which are set by the ItemTool
+        * ``self.motion_handle``    - HanldeInMotion object. which is set by the HandleTool
+    Call ``self.__init_mixin__()`` in the tool`s ``__init__`` and
+    ``self.handle_autoscroll(event.x, event.y)`` in the ``on_motion_notify`` event class
+    of the gaphas tool
     """
-    Helper class for all tools using autoscrolling.
-    """
+    _SCROLL_INTERVALL = 50
+
     def __init_mixin__(self) -> None:
         self._scroll_timeout_id = 0
         self._last_event_pos = (0, 0)
-        self._margin = 30
-        self._speed = 15
+        self._margin = 30  # px distance to border to trigger autoscroll
+        self._speed = 15   # px scrolled distance per timer tick
+
+
+    def handle_autoscroll(self, x: float, y: float) -> None:
+        '''Start or stop autoscrolling based on the current curser position'''
+        self._last_event_pos = (x, y)
+        if self._is_dragging() and any(self._should_autoscroll(x, y)):
+            if not self._scroll_timeout_id:
+                self._scroll_timeout_id = GObject.timeout_add(self._SCROLL_INTERVALL,
+                                                              self._on_autoscroll)
+        else:
+            self._stop_autoscroll()
+
 
     def _is_dragging(self) -> bool:
-        movable = getattr(self, '_movable_items', None)
-        handle = getattr(self, 'motion_handle', None)
+        '''True while this tool is dragging an item or handle'''
+        return bool(getattr(self, '_movable_items', None)) or \
+               bool(getattr(self, 'motion_handle', None))
 
-        if movable:
-            logger.debug(f"[_is_dragging()]: State is moved")
-        elif handle:
-            logger.debug(f"[_is_dragging()]: Handler is moved")
-            
-        return bool(movable) or bool(handle)
 
-    def _should_autoscroll(self, x, y) -> list:
-        '''checks if thresholds gets hit for autoscrolling'''
+    def _should_autoscroll(self, x: float, y: float):
+        '''checks if border thresholds get hit for autoscrolling.
+        -> returns (right, left, bottom, top) boolean for hit borders.
+        '''
         width = self.view.get_allocated_width()
         height = self.view.get_allocated_height()  
 
-        left_bound_hit = x < self._margin
-        rigth_bound_hit = x > width - self._margin
-        top_bound_hit = y < self._margin
-        bottom_bound_hit = y > height - self._margin
-
-        if left_bound_hit or rigth_bound_hit or top_bound_hit or bottom_bound_hit:
-            logger.debug("[_should autoscroll] -> active")
+        left_border_hit = x < self._margin
+        right_border_hit = x > width - self._margin
+        top_border_hit = y < self._margin
+        bottom_border_hit = y > height - self._margin
         
+        return right_border_hit, left_border_hit, bottom_border_hit, top_border_hit
 
 
     def _scroll_view(self, dx: float, dy: float) -> None:
@@ -107,23 +126,21 @@ class AutoscrollMixin:
         h_adj.set_value(h_adj.get_value() + dx)
         v_adj.set_value(v_adj.get_value() + dy)
 
-    def _on_autoscroll(self) -> bool:
 
+    def _on_autoscroll(self) -> bool:
+        '''Timer callback: scroll the view and drags item(s) along.'''
         if not self._is_dragging():
             self._stop_autoscroll()
             return False
         
         x, y = self._last_event_pos
-        scroll = self._should_autoscroll(self._last_event_pos[0], self._last_event_pos[1])
-
-        dx = (scroll[0]-scroll[1]) * self._speed
-        dy = (scroll[2]-scroll[3]) * self._speed
+        scroll_directions = self._should_autoscroll(self._last_event_pos[0],
+                                                    self._last_event_pos[1])
+        dx = (scroll_directions[0]-scroll_directions[1]) * self._speed
+        dy = (scroll_directions[2]-scroll_directions[3]) * self._speed
 
         offset_x= x + dx
         offset_y = y + dy
-
-        logger.debug(f"[_on_autoscroll()] -> last event pos: {x}, {y}")
-        logger.debug(f"[_on_autoscroll()] -> new scroll pos: {offset_x, offset_y}")
 
         if dx ^ dy:
             self._scroll_view(dx, dy)
@@ -144,30 +161,22 @@ class AutoscrollMixin:
                         self._stop_autoscroll()
                         return True
                     
-                    # *2 to compensate for the shifted view coordinates
+                    # *2 factor multiplication to compensate for the shifted view coordinates
+                    # the view already shifted here, to keep the item also aligned with the cursor
+                    # while shifting, we need to add the delta a 2nd time
                     inmotion.move((x+2*dx, y+2*dy))
                     inmotion.last_x = offset_x
                     inmotion.last_y = offset_y
-
-                    logger.debug(f"[_on_autoscroll()] -> new item pos: {offset_x, offset_y}")
 
             elif getattr(self, 'motion_handle', None):
                 self.motion_handle.move((offset_x, offset_y))
             
         return True
 
-    def _stop_autoscroll(self):
+    def _stop_autoscroll(self) -> None:
         if self._scroll_timeout_id:
             GObject.source_remove(self._scroll_timeout_id)
             self._scroll_timeout_id = 0
-
-    def handle_autoscroll(self, x, y) -> None:
-        self._last_event_pos = (x, y)
-        if self._is_dragging() and any(self._should_autoscroll(x, y)):
-            if not self._scroll_timeout_id:
-                self._scroll_timeout_id = GObject.timeout_add(50, self._on_autoscroll)
-        else:
-            self._stop_autoscroll()
 
 
 class PanTool(gaphas.tool.PanTool):
@@ -240,7 +249,6 @@ class MoveItemTool(gaphas.tool.ItemTool, AutoscrollMixin):
             for item in selected_items:
                 if not isinstance(item, Item):
                     continue
-                logger.debug("[MoveItemTool -> movable_items()] -> InMotion object is created for moving state machine in movable-items function")
                 yield InMotion(item, view)
 
     def on_button_press(self, event):
@@ -275,8 +283,6 @@ class MoveItemTool(gaphas.tool.ItemTool, AutoscrollMixin):
                 # When items are to be moved, a button-press should not cause any deselection.
                 # However, the selection is stored, in case no move operation is performed.
                 self.view.handle_new_selection(self._item)
-            logger.debug("[MoveItemTool _> on_button_press()] -> state machine is selected for move in on_button_press function")
-        logger.debug(f"[MoveItemTool -> on_button_press()-> x-value of event GDK_BUTTON_PRESS: {event.x}")    
         if not self.view.is_focus():
             self.view.grab_focus()
 
@@ -307,8 +313,6 @@ class MoveItemTool(gaphas.tool.ItemTool, AutoscrollMixin):
         for inmotion in self._movable_items:
             rel_pos = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
                                                         inmotion.item.handles()[NW])
-            logger.debug(f"[MoveItemTool -> on_button_release()] -> Relative pose to parent when button released: {rel_pos}")
-            logger.debug(f"[MoveItemTool -> on_button_release()] -> Event pose when button released: x:{event.x}, y:{event.y} ")
             if isinstance(inmotion.item, StateView):
                 state_v = inmotion.item
                 state_m = state_v.model
@@ -572,9 +576,6 @@ class MultiSelectionTool(gaphas.tool.RubberbandTool):
     def on_motion_notify(self, event):
         if event.get_state()[1] & Gdk.EventMask.BUTTON_PRESS_MASK and event.get_state()[1] & \
                 constants.RUBBERBAND_MODIFIER:
-            
-            logger.debug(f"[MultiSelectionTool] --------> MultiSelectionTool active <------")
-
             view = self.view
             self.queue_draw(view)
             self.x1, self.y1 = event.x, event.y
@@ -651,20 +652,19 @@ class MoveHandleTool(gaphas.tool.HandleTool, AutoscrollMixin):
         item = self.grabbed_item
         resize_recursive = isinstance(item, StateView) and self.grabbed_handle in item.corner_handles and \
                            event.get_state()[1] & constants.RECURSIVE_RESIZE_MODIFIER
-        
-        logger.debug(f"[MoveHanldeTool]----->MoveHanldeTool active<-----")
 
         if resize_recursive:
             old_size = (item.width, item.height)
 
-        super(MoveHandleTool, self).on_motion_notify(event)
         self.handle_autoscroll(event.x, event.y)
+
+        super(MoveHandleTool, self).on_motion_notify(event)
 
         if resize_recursive:
             item.resize_all_children(old_size)
         if isinstance(item, StateView):
             item.update_minimum_size_of_children()
-
+    
         return True
 
     def on_button_release(self, event):
@@ -843,8 +843,6 @@ class ConnectionCreationTool(ConnectionTool):
     def on_motion_notify(self, event):
         if not self._parent_state_v or not event.get_state()[1] & Gdk.EventMask.BUTTON_PRESS_MASK:
             return False
-
-        logger.debug(f"[ConnectionCreationTool]---->ConnectionCreationTool active<----")
 
         if not self._connection_v:
             # Create new temporary connection, with origin at the start port and target at the cursor

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -316,7 +316,6 @@ class MoveItemTool(gaphas.tool.ItemTool, AutoscrollMixin):
         affected_models = {}
 
         for inmotion in self._movable_items:
-            inmotion.move((event.x, event.y))
             rel_pos = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
                                                         inmotion.item.handles()[NW])
             logger.debug(f"[MoveItemTool -> on_button_release()] -> Relative pose to parent when button released: {rel_pos}")

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -73,7 +73,6 @@ class AutoscrollMixin:
         self._last_event_pos = (0, 0)
         self._margin = 30
         self._speed = 15
-        self._counter = 0
 
     def _is_dragging(self) -> bool:
         movable = getattr(self, '_movable_items', None)
@@ -87,7 +86,7 @@ class AutoscrollMixin:
         return bool(movable) or bool(handle)
 
     def _should_autoscroll(self, x, y) -> list:
-        # wird ständig aufgerufen -> overshoot (nur bei selected object)
+        '''checks if thresholds gets hit for autoscrolling'''
         width = self.view.get_allocated_width()
         height = self.view.get_allocated_height()  
 
@@ -156,7 +155,6 @@ class AutoscrollMixin:
                 v_adj.set_value(v_adj.get_value() + dy)
 
                 self.motion_handle.move((offset_x, offset_y))
-                self._counter += 1
             
         return True
 
@@ -164,10 +162,9 @@ class AutoscrollMixin:
         if self._scroll_timeout_id:
             GObject.source_remove(self._scroll_timeout_id)
             self._scroll_timeout_id = 0
-            self._counter = 0  
 
     def handle_autoscroll(self, x, y) -> None:
-        self._last_event_pos = (x, y) # gets just updated if on_motion_notify is called
+        self._last_event_pos = (x, y)
         if self._is_dragging() and any(self._should_autoscroll(x, y)):
             if not self._scroll_timeout_id:
                 self._scroll_timeout_id = GObject.timeout_add(50, self._on_autoscroll)

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -138,8 +138,11 @@ class AutoscrollMixin:
                     parent_border_right = inmotion.item.parent.width - (inmotion.item.width + inmotion.item.parent.border_width)
                     parent_border_bottom = inmotion.item.parent.height - (inmotion.item.height + inmotion.item.parent.border_width)
                     
-                    if parent_border_left <= rel_pos[0] or parent_border_top <= rel_pos[1] or \
-                    parent_border_right >= rel_pos[0] or parent_border_bottom >= rel_pos[1]:
+                    rel_x, rel_y = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
+                                                        inmotion.item.handles()[NW])
+                    
+                    if rel_x in (parent_border_left, parent_border_right) or \
+                       rel_y in (parent_border_top, parent_border_bottom):
                         self._stop_autoscroll()
                         return
 

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -112,11 +112,11 @@ class AutoscrollMixin:
         height = self.view.get_allocated_height()  
 
         left_border_hit = x < self._margin
-        right_border_hit = x > width - self._margin
         top_border_hit = y < self._margin
+        right_border_hit = x > width - self._margin
         bottom_border_hit = y > height - self._margin
         
-        return right_border_hit, left_border_hit, bottom_border_hit, top_border_hit
+        return left_border_hit, top_border_hit, right_border_hit, bottom_border_hit
 
 
     def _scroll_view(self, dx: float, dy: float) -> None:
@@ -136,8 +136,8 @@ class AutoscrollMixin:
         x, y = self._last_event_pos
         scroll_directions = self._should_autoscroll(self._last_event_pos[0],
                                                     self._last_event_pos[1])
-        dx = (scroll_directions[0]-scroll_directions[1]) * self._speed
-        dy = (scroll_directions[2]-scroll_directions[3]) * self._speed
+        dx = (scroll_directions[2]-scroll_directions[0]) * self._speed
+        dy = (scroll_directions[3]-scroll_directions[1]) * self._speed
 
         offset_x= x + dx
         offset_y = y + dy

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -98,7 +98,14 @@ class AutoscrollMixin:
         if left_bound_hit or rigth_bound_hit or top_bound_hit or bottom_bound_hit:
             logger.debug("[_should autoscroll] -> active")
         
-        return rigth_bound_hit, left_bound_hit, bottom_bound_hit, top_bound_hit
+
+
+    def _scroll_view(self, dx: float, dy: float) -> None:
+        '''Scroll the view by (dx, dy) pixels by adjusting the view object'''
+        h_adj = self.view.get_hadjustment()
+        v_adj = self.view.get_vadjustment()
+        h_adj.set_value(h_adj.get_value() + dx)
+        v_adj.set_value(v_adj.get_value() + dy)
 
     def _on_autoscroll(self) -> bool:
 
@@ -119,13 +126,9 @@ class AutoscrollMixin:
         logger.debug(f"[_on_autoscroll()] -> new scroll pos: {offset_x, offset_y}")
 
         if dx ^ dy:
-            
-            if getattr(self, '_movable_items', None): 
-                h_adj = self.view.get_hadjustment()
-                v_adj = self.view.get_vadjustment()
-                h_adj.set_value(h_adj.get_value() + dx)
-                v_adj.set_value(v_adj.get_value() + dy)
-                
+            self._scroll_view(dx, dy)
+
+            if getattr(self, '_movable_items', None):     
                 for inmotion in self._movable_items:
                     
                     # parent state boarders to stop autoscrolling when boarders are hit
@@ -149,11 +152,6 @@ class AutoscrollMixin:
                     logger.debug(f"[_on_autoscroll()] -> new item pos: {offset_x, offset_y}")
 
             elif getattr(self, 'motion_handle', None):
-                h_adj = self.view.get_hadjustment()
-                v_adj = self.view.get_vadjustment()
-                h_adj.set_value(h_adj.get_value() + dx)
-                v_adj.set_value(v_adj.get_value() + dy)
-
                 self.motion_handle.move((offset_x, offset_y))
             
         return True

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -939,6 +939,7 @@ class ConnectionModificationTool(ConnectionTool):
 
         last_sink = self._current_sink
         self._current_sink = self.motion_handle.move((event.x, event.y))
+        self.handle_autoscroll(event.x, event.y)
 
         self._handle_temporary_connection(last_sink, self._current_sink, modify_target)
 

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -118,7 +118,7 @@ class AutoscrollMixin:
         logger.debug(f"[_on_autoscroll()] -> last event pos: {x}, {y}")
         logger.debug(f"[_on_autoscroll()] -> new scroll pos: {offset_x, offset_y}")
 
-        if dx or dy:
+        if dx ^ dy:
             
             if getattr(self, '_movable_items', None): 
                 h_adj = self.view.get_hadjustment()

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -113,11 +113,11 @@ class AutoscrollMixin:
         dx = (scroll[0]-scroll[1]) * self._speed
         dy = (scroll[2]-scroll[3]) * self._speed
 
-        x_= x + (self._counter * dx)
-        y_ = y + (self._counter * dy)
+        offset_x= x + (self._counter * dx) 
+        offset_y = y + (self._counter * dy)
 
         logger.debug(f"[_on_autoscroll()] -> last event pos: {x}, {y}")
-        logger.debug(f"[_on_autoscroll()] -> new scroll pos: {x_, y_}")
+        logger.debug(f"[_on_autoscroll()] -> new scroll pos: {offset_x, offset_y}")
 
         if dx or dy:
             movable_items = getattr(self, '_movable_items', None)
@@ -129,10 +129,10 @@ class AutoscrollMixin:
                 
                 for inmotion in self._movable_items:
                     
-                    inmotion.move((x_, y_))
+                    inmotion.move((offset_x, offset_y))
                     self._counter += 1
 
-                    logger.debug(f"[_on_autoscroll()] -> new item pos: {x_, y_}")
+                    logger.debug(f"[_on_autoscroll()] -> new item pos: {offset_x, offset_y}")
                     logger.debug(f"[_on_autoscroll()] -> counter: {self._counter}")
 
                     #self._last_event_pos = (x_, y_)  # -> somehow triggers weird jumping behavior
@@ -150,7 +150,7 @@ class AutoscrollMixin:
                 h_adj.set_value(h_adj.get_value() + dx)
                 v_adj.set_value(v_adj.get_value() + dy)
 
-                motion_handle.move((x_, y_))
+                self.motion_handle.move((offset_x, offset_y))
                 self._counter += 1
             
             '''

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -105,7 +105,7 @@ class AutoscrollMixin:
 
         if not self._is_dragging():
             self._stop_autoscroll()
-            return False
+            return
         
         x, y = self._last_event_pos # -> coordinates in editor world space
         scroll = self._should_autoscroll(self._last_event_pos[0], self._last_event_pos[1])
@@ -120,8 +120,8 @@ class AutoscrollMixin:
         logger.debug(f"[_on_autoscroll()] -> new scroll pos: {offset_x, offset_y}")
 
         if dx or dy:
-            movable_items = getattr(self, '_movable_items', None)
-            if movable_items: 
+            
+            if getattr(self, '_movable_items', None): 
                 h_adj = self.view.get_hadjustment()
                 v_adj = self.view.get_vadjustment()
                 h_adj.set_value(h_adj.get_value() + dx)
@@ -129,6 +129,11 @@ class AutoscrollMixin:
                 
                 for inmotion in self._movable_items:
                     
+                for inmotion in self._movable_items:
+                    if inmotion.item.parent.border_width in rel_pos:
+                        self._stop_autoscroll()
+                        return
+
                     inmotion.move((offset_x, offset_y))
                     self._counter += 1
 
@@ -141,10 +146,7 @@ class AutoscrollMixin:
                     an die das Item dann final geheftet wird. es soll aber am Mauszeiger bleiben
                     --> Wie wird das beim ConnectionTool gemacht?
                     '''
-            
-
-            motion_handle = getattr(self, 'motion_handle', None)
-            if motion_handle:
+            elif getattr(self, 'motion_handle', None):
                 h_adj = self.view.get_hadjustment()
                 v_adj = self.view.get_vadjustment()
                 h_adj.set_value(h_adj.get_value() + dx)

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -217,12 +217,14 @@ class ZoomTool(gaphas.tool.ZoomTool):
             return True
 
 
-class MoveItemTool(gaphas.tool.ItemTool):
+class MoveItemTool(gaphas.tool.ItemTool, AutoscrollMixin):
     """This class is responsible for moving states, names, connections, etc.
     """
 
     def __init__(self, view=None, buttons=(1,)):
         super(MoveItemTool, self).__init__(view, buttons)
+        self.__init_mixin__()
+        
         self._item = None
         self._move_name_v = False
         self._old_selection = None
@@ -276,11 +278,24 @@ class MoveItemTool(gaphas.tool.ItemTool):
                 # When items are to be moved, a button-press should not cause any deselection.
                 # However, the selection is stored, in case no move operation is performed.
                 self.view.handle_new_selection(self._item)
-
+            logger.debug("[MoveItemTool _> on_button_press()] -> state machine is selected for move in on_button_press function")
+        logger.debug(f"[MoveItemTool -> on_button_press()-> x-value of event GDK_BUTTON_PRESS: {event.x}")    
         if not self.view.is_focus():
             self.view.grab_focus()
 
         return True
+    
+    
+    def on_motion_notify(self, event):
+        """Autoscroll on drag
+        If one or more items are moved against the boarder of the graphical editor view, the view is moved into
+        the direction of the boarder threshold.
+
+        :param event: The motion event
+        """
+        self.handle_autoscroll(event.x, event.y)
+
+        return super().on_motion_notify(event)
 
     def on_button_release(self, event):
         """Write back changes
@@ -584,13 +599,17 @@ class MultiSelectionTool(gaphas.tool.RubberbandTool):
         return True
 
 
-class MoveHandleTool(gaphas.tool.HandleTool):
+class MoveHandleTool(gaphas.tool.HandleTool, AutoscrollMixin):
     """Tool to move handles around
 
     Handles can be moved using click'n'drag. This is already implemented in the base class `HandleTool`. This class
     extends the behaviour by requiring a modifier key to be pressed when moving ports. It also allows to change the
     modifier key, which are defined in `rafcon.gui.utils.constants`.
     """
+    def __init__(self):
+        super(MoveHandleTool, self).__init__()
+        self.__init_mixin__()
+
 
     def on_button_press(self, event):
         """Handle button press events.
@@ -643,6 +662,7 @@ class MoveHandleTool(gaphas.tool.HandleTool):
             old_size = (item.width, item.height)
 
         super(MoveHandleTool, self).on_motion_notify(event)
+        self.handle_autoscroll(event.x, event.y)
 
         if resize_recursive:
             item.resize_all_children(old_size)
@@ -679,10 +699,11 @@ class MoveHandleTool(gaphas.tool.HandleTool):
         super(MoveHandleTool, self).on_button_release(event)
 
 
-class ConnectionTool(gaphas.tool.ConnectHandleTool):
+class ConnectionTool(gaphas.tool.ConnectHandleTool, AutoscrollMixin):
 
     def __init__(self):
         super(ConnectionTool, self).__init__()
+        self.__init_mixin__()
         self._connection_v = None
         self._start_port_v = None
         self._parent_state_v = None
@@ -839,6 +860,7 @@ class ConnectionCreationTool(ConnectionTool):
 
         last_sink = self._current_sink
         self._current_sink = self.motion_handle.move((event.x, event.y))
+        self.handle_autoscroll(event.x, event.y)
 
         self._handle_temporary_connection(last_sink, self._current_sink, of_target=True)
 

--- a/source/rafcon/gui/mygaphas/tools.py
+++ b/source/rafcon/gui/mygaphas/tools.py
@@ -142,24 +142,24 @@ class AutoscrollMixin:
         offset_x= x + dx
         offset_y = y + dy
 
-        if dx ^ dy:
+        if dx or dy:
             self._scroll_view(dx, dy)
 
             if getattr(self, '_movable_items', None):     
                 for inmotion in self._movable_items:
-                    
-                    # parent state boarders to stop autoscrolling when boarders are hit
-                    parent_border_left = parent_border_top = inmotion.item.parent.border_width
-                    parent_border_right = inmotion.item.parent.width - (inmotion.item.width + inmotion.item.parent.border_width)
-                    parent_border_bottom = inmotion.item.parent.height - (inmotion.item.height + inmotion.item.parent.border_width)
-                    
-                    rel_x, rel_y = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
-                                                        inmotion.item.handles()[NW])
-                    
-                    if rel_x in (parent_border_left, parent_border_right) or \
-                       rel_y in (parent_border_top, parent_border_bottom):
-                        self._stop_autoscroll()
-                        return True
+                    if inmotion.item.parent:
+                        parent_border_left = parent_border_top = inmotion.item.parent.border_width
+                        parent_border_right = inmotion.item.parent.width - (inmotion.item.width + inmotion.item.parent.border_width)
+                        parent_border_bottom = inmotion.item.parent.height - (inmotion.item.height + inmotion.item.parent.border_width)
+
+                        rel_x, rel_y = gap_helper.calc_rel_pos_to_parent(self.view.canvas, inmotion.item,
+                                                            inmotion.item.handles()[NW])
+
+                        #check to stop if parent borders are hit
+                        if rel_x in (parent_border_left, parent_border_right) or \
+                           rel_y in (parent_border_top, parent_border_bottom):
+                            self._stop_autoscroll()
+                            return True
                     
                     # *2 factor multiplication to compensate for the shifted view coordinates
                     # the view already shifted here, to keep the item also aligned with the cursor

--- a/tests/assets/unit_test_state_machines/autoscroll_test/ExecutionState_4_PHVUSJ/core_data.json
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/ExecutionState_4_PHVUSJ/core_data.json
@@ -1,0 +1,48 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.InputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_0"
+        }
+    }, 
+    "name": "ExecutionState 4", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 1, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "state_id": "PHVUSJ"
+}

--- a/tests/assets/unit_test_state_machines/autoscroll_test/ExecutionState_4_PHVUSJ/script.py
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/ExecutionState_4_PHVUSJ/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(2)
+    return "success"

--- a/tests/assets/unit_test_state_machines/autoscroll_test/HierarchyState_1_FQNEQG/ExecutionState_2_MNNCKT/core_data.json
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/HierarchyState_1_FQNEQG/ExecutionState_2_MNNCKT/core_data.json
@@ -1,0 +1,38 @@
+{
+    "__jsonqualname__": "rafcon.core.states.execution_state.ExecutionState", 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "ExecutionState 2", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_0"
+        }
+    }, 
+    "state_id": "MNNCKT"
+}

--- a/tests/assets/unit_test_state_machines/autoscroll_test/HierarchyState_1_FQNEQG/ExecutionState_2_MNNCKT/script.py
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/HierarchyState_1_FQNEQG/ExecutionState_2_MNNCKT/script.py
@@ -1,0 +1,5 @@
+
+def execute(self, inputs, outputs, gvm):
+    self.logger.info("Hello {}".format(self.name))
+    self.preemptive_wait(2)
+    return "success"

--- a/tests/assets/unit_test_state_machines/autoscroll_test/HierarchyState_1_FQNEQG/core_data.json
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/HierarchyState_1_FQNEQG/core_data.json
@@ -1,0 +1,67 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 1, 
+            "from_key": 0, 
+            "from_state": "MNNCKT", 
+            "to_key": 0, 
+            "to_state": "FQNEQG"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "HierarchyState 1", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_0"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "FQNEQG", 
+    "transitions": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "MNNCKT", 
+            "transition_id": 2
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "MNNCKT", 
+            "to_outcome": 0, 
+            "to_state": "FQNEQG", 
+            "transition_id": 3
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/autoscroll_test/core_data.json
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/core_data.json
@@ -1,0 +1,83 @@
+{
+    "__jsonqualname__": "rafcon.core.states.hierarchy_state.HierarchyState", 
+    "data_flows": {
+        "2": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 2, 
+            "from_key": 0, 
+            "from_state": "FQNEQG", 
+            "to_key": 0, 
+            "to_state": "PHVUSJ"
+        }, 
+        "3": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
+            "data_flow_id": 3, 
+            "from_key": 1, 
+            "from_state": "PHVUSJ", 
+            "to_key": 0, 
+            "to_state": "GLNOWX"
+        }
+    }, 
+    "description": null, 
+    "income": {
+        "__jsonqualname__": "rafcon.core.state_elements.logical_port.Income"
+    }, 
+    "input_data_ports": {}, 
+    "name": "autoscroll_test", 
+    "outcomes": {
+        "-2": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "preempted", 
+            "outcome_id": -2
+        }, 
+        "-1": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "aborted", 
+            "outcome_id": -1
+        }, 
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.logical_port.Outcome", 
+            "name": "success", 
+            "outcome_id": 0
+        }
+    }, 
+    "output_data_ports": {
+        "0": {
+            "__jsonqualname__": "rafcon.core.state_elements.data_port.OutputDataPort", 
+            "data_port_id": 0, 
+            "data_type": {
+                "__type__": "__builtin__.int"
+            }, 
+            "default_value": null, 
+            "name": "output_1"
+        }
+    }, 
+    "scoped_variables": {}, 
+    "state_id": "GLNOWX", 
+    "transitions": {
+        "1": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": null, 
+            "from_state": null, 
+            "to_outcome": null, 
+            "to_state": "FQNEQG", 
+            "transition_id": 1
+        }, 
+        "4": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "FQNEQG", 
+            "to_outcome": null, 
+            "to_state": "PHVUSJ", 
+            "transition_id": 4
+        }, 
+        "5": {
+            "__jsonqualname__": "rafcon.core.state_elements.transition.Transition", 
+            "from_outcome": 0, 
+            "from_state": "PHVUSJ", 
+            "to_outcome": 0, 
+            "to_state": "GLNOWX", 
+            "transition_id": 5
+        }
+    }
+}

--- a/tests/assets/unit_test_state_machines/autoscroll_test/core_data.json
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/core_data.json
@@ -8,14 +8,6 @@
             "from_state": "FQNEQG", 
             "to_key": 0, 
             "to_state": "PHVUSJ"
-        }, 
-        "3": {
-            "__jsonqualname__": "rafcon.core.state_elements.data_flow.DataFlow", 
-            "data_flow_id": 3, 
-            "from_key": 1, 
-            "from_state": "PHVUSJ", 
-            "to_key": 0, 
-            "to_state": "GLNOWX"
         }
     }, 
     "description": null, 

--- a/tests/assets/unit_test_state_machines/autoscroll_test/statemachine.json
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/statemachine.json
@@ -1,5 +1,5 @@
 {
     "creation_time": "2026-06-26 10:06:31", 
     "state_machine_version": null, 
-    "used_rafcon_version": "2.3.1"
+    "used_rafcon_version": "2.4.0a1"
 }

--- a/tests/assets/unit_test_state_machines/autoscroll_test/statemachine.json
+++ b/tests/assets/unit_test_state_machines/autoscroll_test/statemachine.json
@@ -1,0 +1,5 @@
+{
+    "creation_time": "2026-06-26 10:06:31", 
+    "state_machine_version": null, 
+    "used_rafcon_version": "2.3.1"
+}

--- a/tests/gui/test_autoscroll.py
+++ b/tests/gui/test_autoscroll.py
@@ -1,0 +1,154 @@
+import os
+import time
+import pytest
+from unittest.mock import MagicMock
+
+import gi
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
+
+from tests import utils as testing_utils
+
+
+# --------------- unit tests --------------------    
+def _make_view(width=800, height=600):
+    view = MagicMock()
+    view.get_allocated_width.return_value = width
+    view.get_allocated_height.return_value = height
+    return view
+
+def _make_dummy_tool(view):
+    from rafcon.gui.mygaphas.tools import AutoscrollMixin
+    class _DummyTool(AutoscrollMixin):
+        def __init__(self, v):
+            self.view = v
+            self.__init_mixin__()
+    return _DummyTool(view)
+
+# (left_border, top_border, right_border, bottom_border)
+@pytest.mark.parametrize("x, y, expected", [
+    (400, 300, (False, False, False, False)), # center, no scroll
+    (5, 300, (True, False, False, False)),    # left margin
+    (400, 5, (False, True, False, False)),  # top margin
+    (795, 300, (False, False, True, False)),  # right margin
+    (400, 595, (False, False, False, True)),  # bottom margn
+])
+def test_should_autoscroll(x, y, expected):
+    tool = _make_dummy_tool(_make_view())
+    assert tool._should_autoscroll(x, y) == expected
+
+def test_is_dragging_false_when_idle():
+    tool = _make_dummy_tool(_make_view())
+    assert tool._is_dragging() is False
+
+def test_is_dragging_true_with_movable_items():
+    tool = _make_dummy_tool(_make_view())
+    tool._movable_items = [MagicMock()]
+    assert tool._is_dragging() is True
+
+def test_is_dragging_true_with_motion_handle():
+    tool = _make_dummy_tool(_make_view())
+    tool.motion_handle = MagicMock()
+    assert tool._is_dragging() is True
+
+@pytest.mark.parametrize("drag_attr, drag_val", [
+        ("_movable_items", [MagicMock()]),  # drag item (MoveItemTool)
+        ("motion_handle", MagicMock()),     # drag handle (MoveHandleTool)
+])
+def test_handle_autoscroll_arms_timer_once_at_border(monkeypatch, drag_attr, drag_val):
+    import rafcon.gui.mygaphas.tools as tools_module
+    calls=[]
+    monkeypatch.setattr(tools_module.GObject, "timeout_add",
+                        lambda intervall, cb: calls.append((intervall, cb)) or 42)
+    tool = _make_dummy_tool(_make_view())
+    setattr(tool, drag_attr, drag_val)     # drag item and handle
+    tool.handle_autoscroll(5, 300)         # left border hit
+    assert tool._scroll_timeout_id == 42
+    assert len(calls) == 1
+    assert calls[0][0] == tool._SCROLL_INTERVALL
+    assert calls[0][1] == tool._on_autoscroll
+
+@pytest.mark.parametrize("drag_attr, drag_val", [
+        ("_movable_items", [MagicMock()]),  # drag item (MoveItemTool)
+        ("motion_handle", MagicMock()),     # drag handle (MoveHandleTool)
+])
+def test_handle_autoscroll_no_double_arm(monkeypatch, drag_attr, drag_val):
+    import rafcon.gui.mygaphas.tools as tools_module
+    calls = []
+    monkeypatch.setattr(tools_module.GObject, "timeout_add",
+                        lambda interval, cb: calls.append(cb) or 42)
+    tool = _make_dummy_tool(_make_view())
+    setattr(tool, drag_attr, drag_val)       # drag item and handle
+    tool.handle_autoscroll(5, 300)
+    tool.handle_autoscroll(5, 300)           # redundantly armed
+    assert len(calls) == 1                   # not re-armed
+
+@pytest.mark.parametrize("drag_attr, drag_val", [
+        ("_movable_items", [MagicMock()]),  # drag item (MoveItemTool)
+        ("motion_handle", MagicMock()),     # drag handle (MoveHandleTool)
+])
+def test_handle_autoscroll_stops_when_not_at_border(monkeypatch, drag_attr, drag_val):
+    import rafcon.gui.mygaphas.tools as tools_module
+    removed = []
+    # create fake stop function for timer
+    monkeypatch.setattr(tools_module.GObject, "source_remove", lambda tid: removed.append(tid))
+    # start a fake timeout_add to not accidently start a real timer, prevent leakage
+    monkeypatch.setattr(tools_module.GObject, "timeout_add", lambda i, cb: 42)
+    tool = _make_dummy_tool(_make_view())
+    setattr(tool, drag_attr, drag_val)       # drag item and handle
+    tool._scroll_timeout_id = 99             # pretend timer is running
+    tool.handle_autoscroll(400, 300)         # center -> no border
+    assert removed == [99]
+    assert tool._scroll_timeout_id == 0
+
+@pytest.mark.parametrize("drag_attr, drag_val", [
+        ("_movable_items", [MagicMock()]),  # drag item (MoveItemTool)
+        ("motion_handle", MagicMock()),     # drag handle (MoveHandleTool)
+])
+def test_handle_autoscroll_not_dragging_does_not_arm(monkeypatch, drag_attr, drag_val):
+    import rafcon.gui.mygaphas.tools as tools_module
+    calls = []
+    monkeypatch.setattr(tools_module.GObject, "timeout_add", lambda i, cb: calls.append(cb) or 42)
+    tool = _make_dummy_tool(_make_view())
+    tool.handle_autoscroll(5, 300)               # at border but NOT dragging
+    assert calls == []
+    assert tool._scroll_timeout_id == 0
+
+def _dragging_tool_with_stubbed_scroll(monkeypatch, x, y, parent=None):
+    tool = _make_dummy_tool(_make_view())        
+    item = MagicMock()
+    if not parent:
+        item.item.parent = None                  # skip parent-border logic
+    else:
+        item.item.parent = MagicMock
+    tool._movable_items = [item]
+    tool._last_event_pos = (x, y)
+    scrolls = []
+    monkeypatch.setattr(tool, "_scroll_view", lambda dx, dy: scrolls.append((dx, dy)))
+    return tool, item, scrolls
+
+def test_on_autoscroll_right_border_positive_dx(monkeypatch):
+    tool, item, scrolls = _dragging_tool_with_stubbed_scroll(monkeypatch, 795, 300)
+    assert tool._on_autoscroll() is True
+    assert scrolls == [(tool._speed, 0)]            # right -> +x, no y
+    item.move.assert_called_once()
+
+def test_on_autoscroll_top_border_negative_dy(monkeypatch):
+    tool, item, scrolls = _dragging_tool_with_stubbed_scroll(monkeypatch, 400, 5)
+    tool._on_autoscroll()
+    assert scrolls == [(0, -tool._speed)]           # top -> no x, -y
+
+def test_on_autoscroll_corner_diagonal(monkeypatch):
+    tool, item, scrolls = _dragging_tool_with_stubbed_scroll(monkeypatch, 795, 595)
+    tool._on_autoscroll()
+    assert scrolls == [(tool._speed, tool._speed)]  # bottom-right -> +x,+y (diagonal)
+
+def test_on_autoscroll_stops_when_not_dragging(monkeypatch):
+    import rafcon.gui.mygaphas.tools as tools_module
+    monkeypatch.setattr(tools_module.GObject, "source_remove", lambda tid: None)
+    tool = _make_dummy_tool(_make_view())
+    tool._last_event_pos = (795, 300)
+    assert tool._on_autoscroll() is False           # not dragging -> returns False and exit
+
+
+# ----------- intergration tests ----------------

--- a/tests/gui/test_autoscroll_integration.py
+++ b/tests/gui/test_autoscroll_integration.py
@@ -1,0 +1,376 @@
+import os
+import time
+import pytest
+
+import gi
+gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
+
+from tests import utils as testing_utils
+
+'''
+NOTICE:
+WRITE UNI-TESTS AND INTEGRATION TESTS IN SEPARATE FILES. 
+GUI singleton models are imported in both tests (e.g. in unit tests by rafcon.mygaphas.tools -> 
+rafcon.gui.controllers.right_click_menu.state -> rafcon.gui.singleton and integration tests directly rafcon.gui.singleton),
+leading to THREADING ISSUES when running both tests sequentially in the same file.
+Reason:
+The singletons get created at frst import. 
+With unit tests importing it first, singletons gets bound to the MainThread, resulting the integration tests 
+crashing, because the singleton objects are now not on the GtkThread (GUI) available, on which the integration 
+tests are running.
+Solution:
+To prevent this confusing multi-threading constellation, just run the tests in seperate scripts.
+'''
+
+# ----------- intergration tests ----------------
+sm_path_autoscroll = os.path.join(testing_utils.TEST_ASSETS_PATH, "unit_test_state_machines", "autoscroll_test")
+
+root_state = "GLNOWX"
+hierarchy_state_1 = "GLNOWX/FQNEQG"
+execution_state_1 = "GLNOWX/FQNEQG/MNNCKT"
+execution_state_2 = "GLNOWX/PHVUSJ"
+
+config_options = {
+"gui_config":  {
+    'HISTORY_ENABLED': True,
+    'GAPHAS_EDITOR_AUTO_FOCUS_OF_ROOT_STATE': False
+},
+# the GUI widget needs to stay in a defined, reproducable size for the autoscroll tests.
+# the editor view size here is (400, 600) 
+"runtime_config": {
+    'MAIN_WINDOW_MAXIMIZED': False,
+    'MAIN_WINDOW_SIZE': (1500, 800),
+    'MAIN_WINDOW_POS': (0, 0),
+    'LEFT_BAR_DOCKED_POS': 400,
+    'RIGHT_BAR_DOCKED_POS': 800,
+    'CONSOLE_DOCKED_POS': 600,
+    'LEFT_BAR_WINDOW_UNDOCKED': False,
+    'RIGHT_BAR_WINDOW_UNDOCKED': False,
+    'CONSOLE_WINDOW_UNDOCKED': False,
+    'LEFT_BAR_HIDDEN': False,
+    'RIGHT_BAR_HIDDEN': False,
+    'CONSOLE_HIDDEN': False
+}}
+
+
+def open_test_state_machine(gui):
+    import rafcon.gui.singleton
+    
+    smm_m = rafcon.gui.singleton.state_machine_manager_model
+
+    main_window_controller = rafcon.gui.singleton.main_window_controller
+    menubar_ctrl = main_window_controller.menu_bar_controller
+    state_machines_ctrl = main_window_controller.state_machines_editor_ctrl
+
+    gui(menubar_ctrl.on_open_activate, None, None, sm_path_autoscroll)
+    time.sleep(0.5)
+    testing_utils.wait_for_gui()
+
+    sm_m = smm_m.state_machines[smm_m.selected_state_machine_id]
+    sm_id = sm_m.state_machine.state_machine_id
+    sm_gaphas_ctrl = state_machines_ctrl.get_controller(sm_id)
+    canvas = sm_gaphas_ctrl.canvas
+    gaphas_view = sm_gaphas_ctrl.view.editor
+
+    return sm_m, canvas, gaphas_view
+
+def close_test_state_machine(gui):
+    import rafcon.gui.singleton
+    menubar_ctrl = rafcon.gui.singleton.main_window_controller.menu_bar_controller
+    gui(menubar_ctrl.on_stop_activate, None)
+    gui(menubar_ctrl.on_close_all_activate, None, None)
+    testing_utils.wait_for_gui()
+
+def _center_state_in_view(view, state_v):
+    from gi.repository import Gdk
+    from rafcon.gui.mygaphas.tools import MoveItemTool
+
+    view_center_x = view.get_allocated_width()/2
+    view_center_y = view.get_allocated_height()/2
+    # pos state in view coordinates
+    i_x, i_y = view.get_matrix_i2v(state_v).transform_point(state_v.width/2, state_v.height/2)
+    d_x = view_center_x -i_x
+    d_y = view_center_y - i_y
+    #move view so state is centered:
+    view._matrix.translate(d_x / view._matrix[0], d_y / view._matrix[3])
+    view.request_update((), view.canvas.get_all_items())
+    cx, cy = view.get_matrix_i2v(state_v).transform_point(state_v.width/2, state_v.height/2)
+    return cx, cy
+
+def _assert_centered(view, state_v, tol=2.0):
+    cx, cy = view.get_matrix_i2v(state_v).transform_point(
+        state_v.width / 2.0, state_v.height / 2.0)
+    center_x = view.get_allocated_width() / 2.0
+    center_y = view.get_allocated_height() / 2.0
+    assert abs(cx - center_x) <= tol, f"x off by {cx - center_x:.1f}px"
+    assert abs(cy - center_y) <= tol, f"y off by {cy - center_y:.1f}px"
+
+def _get_handle_pos(view, state_v, handle):
+    i2v = view.get_matrix_i2v(state_v)
+    item_pos_handle = (handle.pos.x.value, handle.pos.y.value)
+    view_pos_handle = i2v.transform_point(*item_pos_handle)
+    return view_pos_handle
+
+def _make_event(event_type, x, y, button=1, state=None):
+    from gi.repository import Gdk
+    event = Gdk.Event.new(event_type)
+    event.x = float(x)
+    event.y = float(y)
+    if event_type in (Gdk.EventType.BUTTON_PRESS, Gdk.EventType.BUTTON_RELEASE):
+        event.button = button
+    if state is not None:
+        event.state = state
+    return event
+
+def _zoom_into_view(gui, view, x, y):
+    from gi.repository import Gdk
+    from rafcon.gui.mygaphas.tools import ZoomTool
+    tool = gui(ZoomTool, view)
+    scroll_event = _make_event(Gdk.EventType.SCROLL, x, y)
+    while view._matrix[0] <= 15.0:
+        gui(tool.on_scroll, scroll_event)
+    _assert_overflow(view)
+
+
+def _assert_overflow(view, axis="h"):
+    '''Self-checking precondition: there must be off-screen canvas to scroll into.
+    Returns the relevant adjustment so the test can read/set scroll position.'''
+    adj = view.get_hadjustment() if axis == "h" else view.get_vadjustment()
+    assert adj.get_upper() > adj.get_page_size(), (
+        "root state is not larger than the viewport; nothing for autoscroll to "
+        "scroll into (the _enlarge_root_state setup failed)"
+    )
+    return adj
+
+def _get_handle_pos(view, state_v, handle):
+        i2v = view.get_matrix_i2v(state_v)
+        item_pos_handle = (handle.pos.x.value, handle.pos.y.value)
+        view_pos_handle = i2v.transform_point(*item_pos_handle)
+        return view_pos_handle
+
+def _item_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, stop_condition = "BUTTON_RELEASE"):
+    from gi.repository import Gdk
+    from rafcon.gui.mygaphas.tools import MoveItemTool
+    
+    tool = gui(MoveItemTool, view)
+    
+    monkeypatch.setattr(tool, "get_item", lambda: state_v)    # deterministic item grab
+    monkeypatch.setattr("rafcon.gui.mygaphas.guide.GuidedStateMixin.MARGIN", 0)   # disable snapping
+    
+    gui(view.unselect_all); gui(view.select_item, state_v)
+    testing_utils.wait_for_gui()
+    
+    cx, cy = view.get_matrix_i2v(state_v).transform_point(state_v.width/2, state_v.height/2)
+    select_event = _make_event(Gdk.EventType.BUTTON_PRESS, cx, cy)
+    gui(tool.on_button_press, select_event)
+    testing_utils.wait_for_gui()
+    
+    assert tool._item is not None, "tool did not select the state item"
+    
+    move_event = _make_event(Gdk.EventType.MOTION_NOTIFY, cx, cy)
+    move_event.state = move_event.get_state()[1] | Gdk.EventMask.BUTTON_PRESS_MASK
+    ticks = view.get_allocated_width()/2 - 5   # 608 - 5 = 603 ticks -> should trigger autoscroll at x = 1019
+    
+    for i in range(0, int(ticks), 5):
+        move_event.x = cx + i
+        move_event.y = cy
+        gui(tool.on_motion_notify, move_event)
+        testing_utils.wait_for_gui()
+        assert tool._is_dragging(), "item drag did not start"
+        if tool._scroll_timeout_id > 0:
+            break
+    if stop_condition == "BUTTON_RELEASE":
+        stop_event = _make_event(Gdk.EventType.BUTTON_RELEASE, move_event.x, move_event.y)
+        gui(tool.on_button_release, stop_event)
+        testing_utils.wait_for_gui()
+    elif stop_condition == "DRAG_BACK":
+        move_event.x = cx 
+        move_event.y = cy
+        gui(tool.on_motion_notify, move_event)
+        testing_utils.wait_for_gui()
+
+
+def _handle_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, stop_condition="BUTTON_RELEASE"):
+    from gi.repository import Gdk
+    from rafcon.gui.mygaphas.tools import MoveHandleTool
+    from gaphas.item import SE
+    
+    tool = gui(MoveHandleTool)
+    tool.view = view
+    
+    monkeypatch.setattr(tool, "grabbed_item", lambda: state_v)    # deterministic item grab
+    monkeypatch.setattr(tool, "grabbed_handle", lambda: state_v.handles()[SE])
+    # Deactivate guides (snapping)
+    monkeypatch.setattr("rafcon.gui.mygaphas.guide.GuidedStateMixin.MARGIN", 0)
+    
+    gui(view.unselect_all); gui(view.select_item, state_v)
+    testing_utils.wait_for_gui()
+
+    assert tool.grabbed_handle is not None, "tool did not select the handle"
+    # get curent position of handle
+    cx, cy = _get_handle_pos(view, state_v, tool.grabbed_handle())
+    select_event = _make_event(Gdk.EventType.BUTTON_PRESS, cx, cy)
+    gui(tool.on_button_press, select_event)
+    testing_utils.wait_for_gui()
+
+    move_event = _make_event(Gdk.EventType.MOTION_NOTIFY, cx, cy)
+    move_event.state = move_event.get_state()[1] | Gdk.EventMask.BUTTON_PRESS_MASK
+
+    ticks = view.get_allocated_width() - (cx + 5)   # 608 - 5 = 603 ticks -> should trigger autoscroll at x = 1019
+    
+    for i in range(0, int(ticks), 5):
+        move_event.x = cx + i
+        move_event.y = cy
+        gui(tool.on_motion_notify, move_event)
+        testing_utils.wait_for_gui()
+        assert tool._is_dragging(), "item drag did not start"
+        if tool._scroll_timeout_id > 0:
+            break
+    if stop_condition == "BUTTON_RELEASE":
+        stop_event = _make_event(Gdk.EventType.BUTTON_RELEASE, move_event.x, move_event.y)
+        gui(tool.on_button_release, stop_event)
+        testing_utils.wait_for_gui()
+    elif stop_condition == "DRAG_BACK":
+        move_event.x = cx 
+        move_event.y = cy
+        gui(tool.on_motion_notify, move_event)
+        testing_utils.wait_for_gui()
+
+def _connection_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, stop_condition="BUTTON_RELEASE"):
+    from gi.repository import Gdk
+    from gaphas.aspect import HandleFinder
+    from rafcon.gui.mygaphas.tools import ConnectionCreationTool
+
+    def _get_output_port_handle(state_v, port_name=None):
+        from rafcon.gui.mygaphas.items.ports import OutputPortView
+        # state_v.output_ports (or .outputs) holds the OutputPortView objects
+        for port_v in state_v.outputs:
+            if port_name is None or port_v.model.data_port.name == port_name:
+                return port_v, port_v.handle   # the port view and its handle
+        raise AssertionError(f"output port {port_name!r} not found on state")
+
+    tool = gui(ConnectionCreationTool)
+    tool.view = view
+
+    port_v, handle = _get_output_port_handle(state_v, "output_1")
+    # get curent position of handles
+    cx, cy = _get_handle_pos(view, port_v, handle)
+    select_event = _make_event(Gdk.EventType.BUTTON_PRESS, cx, cy)
+    gui(tool.on_button_press, select_event)
+    testing_utils.wait_for_gui()
+
+    move_event = _make_event(Gdk.EventType.MOTION_NOTIFY, cx, cy)
+    move_event.state = move_event.get_state()[1] | Gdk.EventMask.BUTTON_PRESS_MASK
+
+    ticks = view.get_allocated_width() - (cx + 5)   # 608 - 5 = 603 ticks -> should trigger autoscroll at x = 1019
+    for i in range(0, int(ticks), 5): 
+        move_event.x = cx + i
+        move_event.y = cy
+        gui(tool.on_motion_notify, move_event)
+        testing_utils.wait_for_gui()
+        assert tool._is_dragging(), "item drag did not start"
+        if tool._scroll_timeout_id > 0:
+            break
+    if stop_condition == "BUTTON_RELEASE":
+        stop_event = _make_event(Gdk.EventType.BUTTON_RELEASE, move_event.x, move_event.y)
+        gui(tool.on_button_release, stop_event)
+        testing_utils.wait_for_gui()
+    elif stop_condition == "DRAG_BACK":
+        move_event.x = cx 
+        move_event.y = cy
+        gui(tool.on_motion_notify, move_event)
+        testing_utils.wait_for_gui()
+    
+@pytest.mark.parametrize("gui", [config_options], indirect=True)
+def test_autoscroll_item_release_button(gui, monkeypatch):
+    '''drag item into the autoscroll zone, perform one cycle of autoscroll and then release the mouse button
+    to stop the autoscrolling'''
+    from gi.repository import Gdk
+
+    sm_m, canvas, view = open_test_state_machine(gui)
+    state_m = sm_m.get_state_model_by_path(execution_state_2)
+    state_v = canvas.get_view_for_model(state_m)
+
+    x, y = _center_state_in_view(view=view, state_v=state_v); _assert_centered(view, state_v)
+    _zoom_into_view(gui, view, x, y)
+    # release button in autoscroll zone to stop autoscroll
+    _item_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, "BUTTON_RELEASE")
+
+@pytest.mark.parametrize("gui", [config_options], indirect=True)
+def test_autoscroll_item_drag_back(gui, monkeypatch):
+    '''drag item into the autoscroll zone, perform one cycle of autoscroll and then drag the item back
+    to stop the autoscrolling'''
+    from gi.repository import Gdk
+
+    sm_m, canvas, view = open_test_state_machine(gui)
+    state_m = sm_m.get_state_model_by_path(execution_state_2)
+    state_v = canvas.get_view_for_model(state_m)
+
+    x, y = _center_state_in_view(view=view, state_v=state_v); _assert_centered(view, state_v)
+    _zoom_into_view(gui, view, x, y)
+    # drag item back out of autoscroll zone to stop autoscrolling
+    _item_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, "DRAG_BACK")
+
+@pytest.mark.parametrize("gui", [config_options], indirect=True)
+def test_autoscroll_handle_release_button(gui, monkeypatch):
+    '''drag state handle into the autoscroll zone, perform one cycle of autoscroll and then elease the mouse button
+    to stop the autoscrolling'''
+    from gi.repository import Gdk
+    from gaphas.item import SE, NW
+
+    sm_m, canvas, view = open_test_state_machine(gui)
+    state_m = sm_m.get_state_model_by_path(execution_state_2)
+    state_v = canvas.get_view_for_model(state_m)
+
+    x, y = _center_state_in_view(view=view, state_v=state_v); _assert_centered(view, state_v)
+    _zoom_into_view(gui, view, x, y)
+    _handle_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, "BUTTON_RELEASE")
+
+@pytest.mark.parametrize("gui", [config_options], indirect=True)
+def test_autoscroll_handle_drag_back(gui, monkeypatch):
+    '''drag state handle into the autoscroll zone, perform one cycle of autoscroll and then drag the handle back
+    to stop the autoscrolling'''
+    from gi.repository import Gdk
+    from gaphas.item import SE, NW
+
+    sm_m, canvas, view = open_test_state_machine(gui)
+    state_m = sm_m.get_state_model_by_path(execution_state_2)
+    state_v = canvas.get_view_for_model(state_m)
+
+    x, y = _center_state_in_view(view=view, state_v=state_v); _assert_centered(view, state_v)
+    _zoom_into_view(gui, view, x, y)
+    _handle_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, "DRAG_BACK")
+
+@pytest.mark.parametrize("gui", [config_options], indirect=True)
+def test_autoscroll_connection_release_button(gui, monkeypatch):
+    '''drag connection handle into the autoscroll zone, perform one cycle of autoscroll and then elease the mouse button
+    to stop the autoscrolling'''
+    from gi.repository import Gdk
+    from gaphas.item import SE, NW
+
+    sm_m, canvas, view = open_test_state_machine(gui)
+    state_m = sm_m.get_state_model_by_path(execution_state_2)
+    state_v = canvas.get_view_for_model(state_m)
+
+    x, y = _center_state_in_view(view=view, state_v=state_v); _assert_centered(view, state_v)
+    _zoom_into_view(gui, view, x, y)
+    _connection_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, "BUTTON_RELEASE")
+
+@pytest.mark.parametrize("gui", [config_options], indirect=True)
+def test_autoscroll_connection_drag_back(gui, monkeypatch):
+    '''drag connection handle into the autoscroll zone, perform one cycle of autoscroll and then drag the handle back
+    to stop the autoscrolling'''
+    from gi.repository import Gdk
+    from gaphas.item import SE, NW
+
+    sm_m, canvas, view = open_test_state_machine(gui)
+    state_m = sm_m.get_state_model_by_path(execution_state_2)
+    state_v = canvas.get_view_for_model(state_m)
+
+    x, y = _center_state_in_view(view=view, state_v=state_v); _assert_centered(view, state_v)
+    _zoom_into_view(gui, view, x, y)
+    _connection_drag_into_autoscroll_and_stop(gui, view, state_v, monkeypatch, "DRAG_BACK")
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-xs'])

--- a/tests/gui/test_autoscroll_unit.py
+++ b/tests/gui/test_autoscroll_unit.py
@@ -8,7 +8,7 @@ gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
 
 from tests import utils as testing_utils
-
+from tests.utils import call_gui_callback, wait_for_gui
 
 # --------------- unit tests --------------------    
 def _make_view(width=800, height=600):
@@ -149,6 +149,3 @@ def test_on_autoscroll_stops_when_not_dragging(monkeypatch):
     tool = _make_dummy_tool(_make_view())
     tool._last_event_pos = (795, 300)
     assert tool._on_autoscroll() is False           # not dragging -> returns False and exit
-
-
-# ----------- intergration tests ----------------


### PR DESCRIPTION
Added autoscroll feature to rafcon's graphical editor

If a item or handle or connection is dragged against the border of the graphical editor, the view automatically scrolls into the direction of the drag und pulls the selected item with it.
If a item or handle or connection is dragged against a corner of the graphical editor, the view scroll diagonally into the direction of the drag.
If the button is released or the item gets moved away from the editor border, the autoscrolling stops.
If during the autoscroll the border of the parent state is reached, the autoscroll stops.
If two or more items are selected, the relative position of the item gets maintained, until they hit the parent's border.

For now just a continous autoscroll within a fixed threshold (30px) is integrated.

Unit tests and integration tests for interaction with the gui are applied.

To do:
- adapt changelog
- adapt documentation feature list?
- adapt documentation testing with learned lessons? (check integration tests file)
